### PR TITLE
Initial phase of D2X-XL level support

### DIFF
--- a/Data/Color.cs
+++ b/Data/Color.cs
@@ -1,0 +1,32 @@
+﻿/*
+    Copyright (c) 2019 SaladBadger
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+namespace LibDescent.Data
+{
+    public struct Color
+    {
+        public int A { get; set; }
+        public int R { get; set; }
+        public int G { get; set; }
+        public int B { get; set; }
+    }
+}

--- a/Data/HOGFile.cs
+++ b/Data/HOGFile.cs
@@ -187,6 +187,19 @@ namespace LibDescent.Data
         }
 
         /// <summary>
+        /// Writes the current contents of the HOG file to its associated file on disk.
+        /// </summary>
+        public void Write()
+        {
+            if (Filename == null)
+            {
+                throw new InvalidOperationException("This HOG file has no associated filename.");
+            }
+
+            Write(Filename);
+        }
+
+        /// <summary>
         /// Writes the current contents of the HOG file to a file with the given filename.
         /// </summary>
         /// <param name="filename">The filename to write the HOG file to.</param>

--- a/Data/Level/Block.cs
+++ b/Data/Level/Block.cs
@@ -58,7 +58,7 @@ namespace LibDescent.Data
                 {
                     throw new InvalidDataException($"Encountered duplicate definition of segment {segmentId} at line {reader.LastLineNumber}.");
                 }
-                var segment = new Segment(Segment.MaxSegmentSides, Segment.MaxSegmentVerts);
+                var segment = new Segment(Segment.MaxSides, Segment.MaxVertices);
                 segments[segmentId] = segment;
 
                 // Read sides
@@ -85,7 +85,7 @@ namespace LibDescent.Data
                 segmentConnections[segmentId] = BlockCommon.ReadSegmentChildren(reader);
 
                 // Read vertices
-                for (uint vertexNum = 0; vertexNum < Segment.MaxSegmentVerts; vertexNum++)
+                for (uint vertexNum = 0; vertexNum < Segment.MaxVertices; vertexNum++)
                 {
                     (var vertexLocation, var fileVertexNum) = BlockCommon.ReadVertex(reader, false);
                     if (fileVertexNum != vertexNum)
@@ -304,7 +304,7 @@ namespace LibDescent.Data
                 {
                     throw new InvalidDataException($"Encountered duplicate definition of segment {segmentId} at line {reader.LastLineNumber}.");
                 }
-                var segment = new Segment(Segment.MaxSegmentSides, Segment.MaxSegmentVerts);
+                var segment = new Segment(Segment.MaxSides, Segment.MaxVertices);
                 segments[segmentId] = segment;
 
                 // Read sides
@@ -420,7 +420,7 @@ namespace LibDescent.Data
 
                 // Read vertices
                 /*pSegment->m_nShape = 0;*/ // DLE non-cuboid - for reference
-                for (uint vertexNum = 0; vertexNum < Segment.MaxSegmentVerts; vertexNum++)
+                for (uint vertexNum = 0; vertexNum < Segment.MaxVertices; vertexNum++)
                 {
                     (var vertexLocation, var fileVertexNum) = BlockCommon.ReadVertex(reader, true);
 

--- a/Data/Level/DynamicLight.cs
+++ b/Data/Level/DynamicLight.cs
@@ -51,7 +51,7 @@ namespace LibDescent.Data
         public LightDelta(Side targetSide)
         {
             this.targetSide = targetSide;
-            vertexDeltas = new Fix[targetSide.GetNumVertices()];
+            vertexDeltas = new Fix[Side.MaxVertices];
         }
     }
 }

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -1201,7 +1201,6 @@ namespace LibDescent.Data
         protected abstract ILevel Level { get; }
         protected abstract int LevelVersion { get; }
         protected abstract ushort GameDataVersion { get; }
-        private const int GameDataSize = 143;
 
         /// <summary>
         /// The .POF file names to write into the level, for consumers that need it.
@@ -1473,12 +1472,13 @@ namespace LibDescent.Data
             FileInfo fileInfo = new FileInfo();
             fileInfo.signature = 0x6705;
             fileInfo.version = GameDataVersion;
-            fileInfo.size = GameDataSize;
+            fileInfo.size = 0;
             fileInfo.mineFilename = ""; // Not used, leave blank
             fileInfo.levelNumber = 0; // Doesn't seem to be used by Descent
 
             // We'll have to rewrite FileInfo later, but write it now to make space
             WriteFileInfo(writer, fileInfo);
+            fileInfo.size = (int)(writer.BaseStream.Position - fileInfoOffset);
 
             if (GameDataVersion >= 14)
             {

--- a/Data/Level/Level.cs
+++ b/Data/Level/Level.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace LibDescent.Data
 {
@@ -159,6 +160,8 @@ namespace LibDescent.Data
 
         public new List<IMatCenter> MatCenters { get; } = new List<IMatCenter>();
 
+        public List<SegmentGroup> SegmentGroups { get; } = new List<SegmentGroup>();
+
 #pragma warning disable CA1819 // Callers can modify the contents of the array; this is by design.
         public FogPreset[] FogPresets { get; } = new FogPreset[]
 #pragma warning restore CA1819
@@ -220,6 +223,16 @@ namespace LibDescent.Data
                 }
             }
             return -1;
+        }
+
+        public static IReadOnlyList<MatCenter> GetRobotMatCenters(this ILevel level)
+        {
+            return level.MatCenters.Where(m => m is MatCenter).Cast<MatCenter>().ToList();
+        }
+
+        public static IReadOnlyList<PowerupMatCenter> GetPowerupMatCenters(this ILevel level)
+        {
+            return level.MatCenters.Where(m => m is PowerupMatCenter).Cast<PowerupMatCenter>().ToList();
         }
     }
 }

--- a/Data/Level/Level.cs
+++ b/Data/Level/Level.cs
@@ -34,7 +34,7 @@ namespace LibDescent.Data
         List<Wall> Walls { get; }
         IReadOnlyList<ITrigger> Triggers { get; }
         List<Side> ReactorTriggerTargets { get; }
-        List<MatCenter> MatCenters { get; }
+        IReadOnlyList<IMatCenter> MatCenters { get; }
 
         void WriteToStream(Stream stream);
     }
@@ -53,8 +53,6 @@ namespace LibDescent.Data
 
         public const int MaxReactorTriggerTargets = 10;
         public List<Side> ReactorTriggerTargets { get; } = new List<Side>(MaxReactorTriggerTargets);
-
-        public List<MatCenter> MatCenters { get; } = new List<MatCenter>();
     }
 
     public class D1Level : ILevel
@@ -62,6 +60,8 @@ namespace LibDescent.Data
         private DescentLevelCommon _commonData = new DescentLevelCommon();
 
         public List<D1Trigger> Triggers { get; } = new List<D1Trigger>();
+
+        public List<MatCenter> MatCenters { get; } = new List<MatCenter>();
 
         #region ILevel implementation
         public string LevelName { get => _commonData.LevelName; set => _commonData.LevelName = value; }
@@ -71,7 +71,7 @@ namespace LibDescent.Data
         public List<Wall> Walls => _commonData.Walls;
         IReadOnlyList<ITrigger> ILevel.Triggers => Triggers;
         public List<Side> ReactorTriggerTargets => _commonData.ReactorTriggerTargets;
-        public List<MatCenter> MatCenters => _commonData.MatCenters;
+        IReadOnlyList<IMatCenter> ILevel.MatCenters => MatCenters;
         #endregion
 
         public static D1Level CreateFromStream(Stream stream)
@@ -90,6 +90,8 @@ namespace LibDescent.Data
         private DescentLevelCommon _commonData = new DescentLevelCommon();
 
         public List<D2Trigger> Triggers { get; } = new List<D2Trigger>();
+
+        public List<MatCenter> MatCenters { get; } = new List<MatCenter>();
 
         public string PaletteName { get; set; }
 
@@ -123,7 +125,7 @@ namespace LibDescent.Data
         public List<Wall> Walls => _commonData.Walls;
         IReadOnlyList<ITrigger> ILevel.Triggers => Triggers;
         public List<Side> ReactorTriggerTargets => _commonData.ReactorTriggerTargets;
-        public List<MatCenter> MatCenters => _commonData.MatCenters;
+        IReadOnlyList<IMatCenter> ILevel.MatCenters => MatCenters;
         #endregion
 
         public static D2Level CreateFromStream(Stream stream)
@@ -149,6 +151,59 @@ namespace LibDescent.Data
     {
         public Color color;
         public float density;
+    }
+
+    public class D2XXLLevel : D2Level, ILevel
+    {
+        public new List<D2XXLTrigger> Triggers { get; } = new List<D2XXLTrigger>();
+
+        public new List<IMatCenter> MatCenters { get; } = new List<IMatCenter>();
+
+#pragma warning disable CA1819 // Callers can modify the contents of the array; this is by design.
+        public FogPreset[] FogPresets { get; } = new FogPreset[]
+#pragma warning restore CA1819
+        {
+            // Default values are adapted from DLE.
+            // Water
+            new FogPreset
+            {
+                color = new Color{ A = 255, R = (int)(255.0f * 0.2f), G = (int)(255.0f * 0.4f), B = (int)(255.0f * 0.6f) },
+                density = (11f / 20f)
+            },
+            // Lava
+            new FogPreset
+            {
+                color = new Color{ A = 255, R = (int)(255.0f * 0.8f), G = (int)(255.0f * 0.4f), B = (int)(255.0f * 0.0f) },
+                density = (2f / 20f)
+            },
+            // LightFog
+            new FogPreset
+            {
+                color = new Color{ A = 255, R = (int)(255.0f * 0.7f), G = (int)(255.0f * 0.7f), B = (int)(255.0f * 0.7f) },
+                density = (4f / 20f)
+            },
+            // HeavyFog
+            new FogPreset
+            {
+                color = new Color{ A = 255, R = (int)(255.0f * 0.7f), G = (int)(255.0f * 0.7f), B = (int)(255.0f * 0.7f) },
+                density = (11f / 20f)
+            }
+        };
+
+        #region ILevel implementation
+        IReadOnlyList<ITrigger> ILevel.Triggers => Triggers;
+        IReadOnlyList<IMatCenter> ILevel.MatCenters => MatCenters;
+        #endregion
+
+        public static new D2XXLLevel CreateFromStream(Stream stream)
+        {
+            return new D2XXLLevelReader(stream).Load();
+        }
+
+        public new void WriteToStream(Stream stream)
+        {
+            new D2XXLLevelWriter(this, stream).Write();
+        }
     }
 
     public static partial class Extensions

--- a/Data/Level/Level.cs
+++ b/Data/Level/Level.cs
@@ -234,5 +234,15 @@ namespace LibDescent.Data
         {
             return level.MatCenters.Where(m => m is PowerupMatCenter).Cast<PowerupMatCenter>().ToList();
         }
+
+        public static IReadOnlyList<ITrigger> GetWallTriggers(this ILevel level)
+        {
+            return level.Triggers.Where(t => t.ConnectedWalls.Count > 0).ToList();
+        }
+
+        public static IReadOnlyList<ITrigger> GetObjectTriggers(this ILevel level)
+        {
+            return level.Triggers.Where(t => t.ConnectedObjects.Count > 0).ToList();
+        }
     }
 }

--- a/Data/Level/Level.cs
+++ b/Data/Level/Level.cs
@@ -137,6 +137,20 @@ namespace LibDescent.Data
         }
     }
 
+    public enum FogType
+    {
+        Water = 0,
+        Lava = 1,
+        LightFog = 2,
+        HeavyFog = 3
+    }
+
+    public struct FogPreset
+    {
+        public Color color;
+        public float density;
+    }
+
     public static partial class Extensions
     {
         // It's not clear why .NET doesn't define this already, but it doesn't.

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -47,7 +47,12 @@ namespace LibDescent.Data
         Ghost,
         Light,
         Coop,
-        Marker
+        Marker,
+        Cambot, // D2X-XL
+        Monsterball, // D2X-XL
+        Smoke, // D2X-XL
+        Explosion, // D2X-XL
+        Effect, // D2X-XL
     }
     public enum ControlType
     {
@@ -68,6 +73,7 @@ namespace LibDescent.Data
         Light,
         Remote,
         ControlCenter,
+        Waypoint, // D2X-XL
     }
 
     public enum MovementType
@@ -87,6 +93,12 @@ namespace LibDescent.Data
         Powerup,
         Morph,
         WeaponVClip,
+        Thruster, // D2X-XL: like afterburner, but doesn't cast light
+        ExplosionBlast, // D2X-XL: white explosion light blast
+        Shrapnel, // D2X-XL
+        Particle, // D2X-XL
+        Lightning, // D2X-XL
+        Sound, // D2X-XL
     }
 
     //Move info
@@ -130,6 +142,68 @@ namespace LibDescent.Data
         public int count;
     }
 
+    // D2X-XL
+    public struct WaypointInfo
+    {
+        public int waypointId;
+        public int nextWaypointId;
+        public int speed;
+    }
+
+    // D2X-XL
+    public struct ParticleInfo
+    {
+        public int nLife;
+        // nSize is a 2-element array in DLE, but the second element isn't used...
+        // I guess that means we don't need it?
+        public int nSize;
+        public int nParts;
+        public int nSpeed;
+        public int nDrift;
+        public int nBrightness;
+        public Color color;
+        public byte nSide;
+        public byte nType;
+        public bool enabled;
+    }
+
+    // D2X-XL
+    public struct LightningInfo
+    {
+        public int nLife;
+        public int nDelay;
+        public int nLength;
+        public int nAmplitude;
+        public int nOffset;
+        public int nWayPoint;
+        public short nBolts;
+        public short nId;
+        public short nTarget;
+        public short nNodes;
+        public short nChildren;
+        public short nFrames;
+        public byte nWidth;
+        public byte nAngle;
+        public byte nStyle;
+        public byte nSmoothe;
+        public byte bClamp;
+        public byte bPlasma;
+        public byte bSound;
+        public byte bRandom;
+        public byte bInPlane;
+        public Color color;
+        public bool enabled;
+    }
+
+    // D2X-XL
+    public struct SoundInfo
+    {
+        public string filename;
+        // Expected range 0-10, indicates how loud the sound should be
+        public int volume;
+        public bool enabled;
+    }
+
     //Render info
     public class PolymodelInfo
     {
@@ -157,6 +231,10 @@ namespace LibDescent.Data
         public RenderType renderType;
         public byte flags;
 
+        /// <summary>
+        /// Indicates if this object is only present in multiplayer modes. D2X-XL only.
+        /// </summary>
+        public bool MultiplayerOnly { get; set; }
         public short segnum;
         public short attachedObject;
 
@@ -176,6 +254,10 @@ namespace LibDescent.Data
         public AIInfo aiInfo = new AIInfo();
         public ExplosionInfo explosionInfo = new ExplosionInfo();
         public int powerupCount;
+        public WaypointInfo waypointInfo = new WaypointInfo();
+        public ParticleInfo particleInfo = new ParticleInfo();
+        public LightningInfo lightningInfo = new LightningInfo();
+        public SoundInfo soundInfo = new SoundInfo();
         //Render info
         public PolymodelInfo modelInfo = new PolymodelInfo();
         public SpriteInfo spriteInfo;

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -181,5 +181,10 @@ namespace LibDescent.Data
         public SpriteInfo spriteInfo;
 
         public int sig;
+
+        /// <summary>
+        /// The object trigger assigned to this object. D2X-XL only.
+        /// </summary>
+        public D2XXLTrigger Trigger { get; set; }
     }
 }

--- a/Data/Level/MatCenter.cs
+++ b/Data/Level/MatCenter.cs
@@ -25,7 +25,24 @@ using System.Collections.Generic;
 
 namespace LibDescent.Data
 {
-    public class MatCenter
+    public interface IMatCenter
+    {
+        Segment Segment { get; }
+
+        /// <summary>
+        /// The number of hit points the matcen has.
+        /// Not actually implemented in Descent or Descent 2.
+        /// </summary>
+        Fix HitPoints { get; set; }
+
+        /// <summary>
+        /// The time between consecutive spawns from the matcen.
+        /// Descent and Descent 2 ignore this value and always use 5 seconds.
+        /// </summary>
+        Fix Interval { get; set; }
+    }
+
+    public class MatCenter : IMatCenter
     {
         public MatCenter(Segment segment)
         {
@@ -36,19 +53,8 @@ namespace LibDescent.Data
         }
 
         public Segment Segment { get; }
-
         public SortedSet<uint> SpawnedRobotIds { get; }
-
-        /// <summary>
-        /// The number of hit points the matcen has.
-        /// Not actually implemented in Descent or Descent 2.
-        /// </summary>
         public Fix HitPoints { get; set; }
-
-        /// <summary>
-        /// The time between consecutive spawns from the matcen.
-        /// Descent and Descent 2 ignore this value and always use 5 seconds.
-        /// </summary>
         public Fix Interval { get; set; }
 
         internal void InitializeSpawnedRobots(uint[] robotListFlags)
@@ -62,6 +68,40 @@ namespace LibDescent.Data
                 if ((robotListFlags[arrayIndex] & (1 << flagOffset)) != 0)
                 {
                     SpawnedRobotIds.Add((uint)robotId);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A D2X-XL-specific variant of a matcen that spawns powerups instead of robots.
+    /// </summary>
+    public class PowerupMatCenter : IMatCenter
+    {
+        public PowerupMatCenter(Segment segment)
+        {
+            Segment = segment ?? throw new ArgumentNullException(nameof(segment));
+            SpawnedPowerupIds = new SortedSet<uint>();
+            HitPoints = 500;
+            Interval = 5;
+        }
+
+        public Segment Segment { get; }
+        public SortedSet<uint> SpawnedPowerupIds { get; }
+        public Fix HitPoints { get; set; }
+        public Fix Interval { get; set; }
+
+        internal void InitializeSpawnedPowerups(uint[] powerupListFlags)
+        {
+            SpawnedPowerupIds.Clear();
+            int arrayElementSize = sizeof(uint) * 8;
+            for (int powerupId = 0; powerupId < powerupListFlags.Length * arrayElementSize; powerupId++)
+            {
+                int flagOffset;
+                int arrayIndex = Math.DivRem(powerupId, arrayElementSize, out flagOffset);
+                if ((powerupListFlags[arrayIndex] & (1 << flagOffset)) != 0)
+                {
+                    SpawnedPowerupIds.Add((uint)powerupId);
                 }
             }
         }

--- a/Data/Level/Segment.cs
+++ b/Data/Level/Segment.cs
@@ -66,7 +66,7 @@ namespace LibDescent.Data
 
         public Side[] Sides { get; }
         public LevelVertex[] Vertices { get; }
-        public MatCenter MatCenter { get; set; }
+        public IMatCenter MatCenter { get; set; }
         public SegFunction Function
         {
             get => (SegFunction)special;

--- a/Data/Level/Segment.cs
+++ b/Data/Level/Segment.cs
@@ -20,7 +20,6 @@
     SOFTWARE.
 */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -54,8 +53,8 @@ namespace LibDescent.Data
 
     public partial class Segment
     {
-        public const int MaxSegmentSides = 6;
-        public const int MaxSegmentVerts = 8;
+        public const int MaxSides = 6;
+        public const int MaxVertices = 8;
         private static readonly int[,] SideVerts = { { 7, 6, 2, 3 }, { 0, 4, 7, 3 }, { 0, 1, 5, 4 }, { 2, 6, 5, 1 }, { 4, 5, 6, 7 }, { 3, 2, 1, 0 } };
         private static readonly int[] OppositeSideTable = { 2, 3, 0, 1, 5, 4 };
         private static readonly int[,] SideNeighborTable = { { 4, 3, 5, 1 }, { 2, 4, 0, 5 }, { 5, 3, 4, 1 }, { 0, 4, 2, 5 }, { 2, 3, 0, 1 }, { 0, 3, 2, 1 } };
@@ -94,7 +93,7 @@ namespace LibDescent.Data
         public Fix Height => (GetSide(SegSide.Up).Center - GetSide(SegSide.Down).Center).Mag();
         #endregion
 
-        public Segment(uint numSides = MaxSegmentSides, uint numVertices = MaxSegmentVerts)
+        public Segment(uint numSides = MaxSides, uint numVertices = MaxVertices)
         {
             Sides = new Side[numSides];
             Vertices = new LevelVertex[numVertices];
@@ -113,5 +112,21 @@ namespace LibDescent.Data
 
         internal (Side side, Edge edge) GetSideNeighbor(uint sideNum, Edge atEdge)
             => (Sides[SideNeighborTable[sideNum, (int)atEdge]], (Edge)EdgeNeighborTable[sideNum, (int)atEdge]);
+    }
+
+    public enum SegOwner
+    {
+        Neutral = -1,
+        Unowned = 0,
+        BlueTeam = 1,
+        RedTeam = 2,
+    }
+
+    public class SegmentGroup : List<D2XXLSegment> { }
+
+    public class D2XXLSegment : Segment
+    {
+        public SegOwner Owner { get; set; } = SegOwner.Neutral;
+        public SegmentGroup Group { get; set; }
     }
 }

--- a/Data/Level/Side.cs
+++ b/Data/Level/Side.cs
@@ -30,7 +30,9 @@ namespace LibDescent.Data
 
     public class Side
     {
-        public Side(Segment parent, uint sideNum, uint numVertices = 4)
+        public const int MaxVertices = 4;
+
+        public Side(Segment parent, uint sideNum, uint numVertices = MaxVertices)
         {
             Segment = parent;
             SideNum = sideNum;

--- a/Data/Level/Trigger.cs
+++ b/Data/Level/Trigger.cs
@@ -140,6 +140,16 @@ namespace LibDescent.Data
         /// A value used by the trigger's action. Effect depends on trigger type.
         /// </summary>
         ValueType Value { get; set; }
+
+        /// <summary>
+        /// A list of the walls that activate this trigger.
+        /// </summary>
+        List<Wall> ConnectedWalls { get; }
+
+        /// <summary>
+        /// A list of the objects that activate this trigger. D2X-XL only.
+        /// </summary>
+        List<LevelObject> ConnectedObjects { get; }
     }
 
     /// <summary>
@@ -155,6 +165,10 @@ namespace LibDescent.Data
         public List<Side> Targets { get; } = new List<Side>();
 
         public ValueType Value { get => value; set => this.value = (int)value; }
+
+        public List<Wall> ConnectedWalls { get; } = new List<Wall>();
+
+        public List<LevelObject> ConnectedObjects => new List<LevelObject>();
 
         public ushort Flags { get; set; }
 
@@ -175,6 +189,10 @@ namespace LibDescent.Data
         public List<Side> Targets { get; } = new List<Side>();
 
         public ValueType Value { get => fixValue; set => fixValue = (Fix)value; }
+
+        public List<Wall> ConnectedWalls { get; } = new List<Wall>();
+
+        public List<LevelObject> ConnectedObjects => new List<LevelObject>();
 
         public D1TriggerFlags Flags { get; set; }
 
@@ -200,6 +218,10 @@ namespace LibDescent.Data
         /// </summary>
         public ValueType Value { get => fixValue; set => fixValue = (Fix)value; }
 
+        public List<Wall> ConnectedWalls { get; } = new List<Wall>();
+
+        public List<LevelObject> ConnectedObjects => new List<LevelObject>();
+
         public D2TriggerFlags Flags { get; set; }
 
         /// <summary>
@@ -220,6 +242,10 @@ namespace LibDescent.Data
         public List<Side> Targets { get; } = new List<Side>();
 
         public ValueType Value { get => fixValue; set => fixValue = (Fix)value; }
+
+        public List<Wall> ConnectedWalls { get; } = new List<Wall>();
+
+        public List<LevelObject> ConnectedObjects { get; } = new List<LevelObject>();
 
         public D2XXLTriggerFlags Flags { get; set; }
 

--- a/Data/Level/Trigger.cs
+++ b/Data/Level/Trigger.cs
@@ -69,13 +69,19 @@ namespace LibDescent.Data
         NoMessage = 0x1,
         OneShot = 0x2,
         Disabled = 0x4, // D2 sets this on a one-shot trigger when activated
-#if false
+    }
+
+    [Flags]
+    public enum D2XXLTriggerFlags
+    {
+        NoMessage = 0x1,
+        OneShot = 0x2,
+        Disabled = 0x4, // D2 sets this on a one-shot trigger when activated
         Permanent = 0x8, // D2X-XL only; control panel not destroyed when activated
         Alternate = 0x10, // D2X-XL only; trigger type inverts between activations
         SetOrient = 0x20, // D2X-XL only
         Silent = 0x40, // D2X-XL only
         AutoPlay = 0x80, // D2X-XL only
-#endif
     }
 
     public interface ITrigger
@@ -155,6 +161,30 @@ namespace LibDescent.Data
         public ValueType Value { get => fixValue; set => fixValue = (Fix)value; }
 
         public D2TriggerFlags Flags { get; set; }
+
+        /// <summary>
+        /// Appears to have been intended to govern the "cooldown" time of repeatable triggers.
+        /// Descent does not actually make use of this value.
+        /// </summary>
+        public int Time { get; set; }
+    }
+
+    public class D2XXLTrigger : ITrigger
+    {
+        public const int MaxWallsPerLink = 10;
+
+        private Fix fixValue;
+
+        public TriggerType Type { get; set; }
+
+        public List<Side> Targets { get; } = new List<Side>();
+
+        /// <summary>
+        /// Descent 2 does not have any trigger types that use Value.
+        /// </summary>
+        public ValueType Value { get => fixValue; set => fixValue = (Fix)value; }
+
+        public D2XXLTriggerFlags Flags { get; set; }
 
         /// <summary>
         /// Appears to have been intended to govern the "cooldown" time of repeatable triggers.

--- a/Data/Level/Trigger.cs
+++ b/Data/Level/Trigger.cs
@@ -25,6 +25,9 @@ using System.Collections.Generic;
 
 namespace LibDescent.Data
 {
+    /// <summary>
+    /// The kind of action a trigger performs when activated.
+    /// </summary>
     public enum TriggerType
     {
         OpenDoor,
@@ -41,6 +44,48 @@ namespace LibDescent.Data
         IllusionWall,
         LightOff,
         LightOn,
+    }
+
+    public enum D2XXLTriggerType
+    {
+        OpenDoor,
+        CloseDoor,
+        Matcen,
+        Exit,
+        SecretExit,
+        IllusionOff,
+        IllusionOn,
+        UnlockDoor,
+        LockDoor,
+        OpenWall,
+        CloseWall,
+        IllusionWall,
+        LightOff,
+        LightOn,
+        // D2X-XL-specific types
+        Teleport,
+        SpeedBoost,
+        Camera,
+        ShieldDrain,
+        EnergyDrain,
+        ChangeTexture,
+        SmokeLife,
+        SmokeSpeed,
+        SmokeDensity,
+        SmokeSize,
+        SmokeDrift,
+        Countdown,
+        SpawnRobot,
+        SmokeBrightness,
+        MovePlayerStart,
+        Message,
+        Sound,
+        Master,
+        EnableTrigger,
+        DisableTrigger,
+        DisarmRobot,
+        ReprogramRobot,
+        ShakeMine,
     }
 
     [Flags]
@@ -86,11 +131,6 @@ namespace LibDescent.Data
 
     public interface ITrigger
     {
-        /// <summary>
-        /// The kind of action this trigger performs when activated.
-        /// </summary>
-        TriggerType Type { get; set; }
-
         /// <summary>
         /// A list of the sides this trigger acts on.
         /// </summary>
@@ -175,13 +215,10 @@ namespace LibDescent.Data
 
         private Fix fixValue;
 
-        public TriggerType Type { get; set; }
+        public D2XXLTriggerType Type { get; set; }
 
         public List<Side> Targets { get; } = new List<Side>();
 
-        /// <summary>
-        /// Descent 2 does not have any trigger types that use Value.
-        /// </summary>
         public ValueType Value { get => fixValue; set => fixValue = (Fix)value; }
 
         public D2XXLTriggerFlags Flags { get; set; }

--- a/Data/Level/Wall.cs
+++ b/Data/Level/Wall.cs
@@ -42,13 +42,13 @@ namespace LibDescent.Data
     {
         Blasted = 0x01, // Destroyed blastable wall
         DoorOpened = 0x02, // Door starts opened
-        //RenderAdditive = 0x04, // D2X-XL only
+        RenderAdditive = 0x04, // Wall is partially transparent (D2X-XL only)
         DoorLocked = 0x08, // Door starts locked
         DoorAuto = 0x10, // Door closes automatically
         IllusionOff = 0x20, // Illusionary wall starts invisible
-        WallSwitch = 0x40, // Opened by wall switch (D2 only; check source, doesn't sound necessary???)
+        WallSwitch = 0x40, // Opened by wall switch (D2 only; not actually used)
         BuddyProof = 0x80, // Guide-bot treats as impassible (D2 only)
-        //IgnoreMarker = 0x100, // D2X-XL only
+        IgnoreMarker = 0x100, // Door cannot be kept open by markers (D2X-XL only)
     }
 
     public enum WallState

--- a/Tests/MiscLevelLoadTests.cs
+++ b/Tests/MiscLevelLoadTests.cs
@@ -27,6 +27,7 @@ namespace LibDescent.Tests
             }
             Assert.NotNull(level);
             Assert.IsInstanceOf<D2Level>(level);
+            Assert.IsNotInstanceOf<D2XXLLevel>(level);
         }
 
         // Levels saved by DEVIL (and apparently beta versions of DMB) have some differences;
@@ -48,8 +49,7 @@ namespace LibDescent.Tests
             var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
             ILevel level = LevelFactory.CreateFromStream(hogFile.GetLumpAsStream("level3.rl2"));
             Assert.NotNull(level);
-            //Assert.IsInstanceOf<D2XXLLevel>(level);
-            Assert.Fail();
+            Assert.IsInstanceOf<D2XXLLevel>(level);
         }
     }
 }

--- a/Tests/MiscLevelLoadTests.cs
+++ b/Tests/MiscLevelLoadTests.cs
@@ -41,5 +41,15 @@ namespace LibDescent.Tests
             }
             Assert.NotNull(level);
         }
+
+        [Test]
+        public void TestAutoD2XXLLevelLoad()
+        {
+            var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
+            ILevel level = LevelFactory.CreateFromStream(hogFile.GetLumpAsStream("level3.rl2"));
+            Assert.NotNull(level);
+            //Assert.IsInstanceOf<D2XXLLevel>(level);
+            Assert.Fail();
+        }
     }
 }

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -282,6 +282,9 @@ namespace LibDescent.Tests
 
             // Trigger 0 is the exit trigger
             Assert.AreSame(level.Triggers[0], level.Walls[0].Trigger);
+            Assert.AreEqual(1, level.Triggers[0].ConnectedWalls.Count);
+            Assert.AreSame(level.Walls[0], level.Triggers[0].ConnectedWalls[0]);
+            Assert.IsEmpty(level.Triggers[0].ConnectedObjects);
             Assert.IsEmpty(level.Triggers[0].Targets);
             Assert.AreEqual(D1TriggerFlags.Exit, level.Triggers[0].Flags);
             // .rdl (D1) should not use trigger type
@@ -292,6 +295,8 @@ namespace LibDescent.Tests
 
             // Trigger 2 is a matcen trigger
             Assert.AreSame(level.Triggers[2], level.Walls[10].Trigger);
+            Assert.AreEqual(1, level.Triggers[2].ConnectedWalls.Count);
+            Assert.AreSame(level.Walls[10], level.Triggers[2].ConnectedWalls[0]);
             Assert.AreEqual(1, level.Triggers[2].Targets.Count);
             Assert.AreSame(level.Segments[16].Sides[5], level.Triggers[2].Targets[0]);
             Assert.AreEqual(D1TriggerFlags.MatCenter, level.Triggers[2].Flags);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -224,6 +224,9 @@ namespace LibDescent.Tests
 
             // Trigger 0 - control panel - open door
             Assert.AreSame(level.Triggers[0], level.Walls[6].Trigger);
+            Assert.AreEqual(1, level.Triggers[0].ConnectedWalls.Count);
+            Assert.AreSame(level.Walls[6], level.Triggers[0].ConnectedWalls[0]);
+            Assert.IsEmpty(level.Triggers[0].ConnectedObjects);
             Assert.AreEqual(1, level.Triggers[0].Targets.Count);
             Assert.AreSame(level.Segments[6].Sides[0], level.Triggers[0].Targets[0]);
             Assert.AreEqual(D2TriggerFlags.NoMessage, level.Triggers[0].Flags);

--- a/Tests/Rl2XLTests.cs
+++ b/Tests/Rl2XLTests.cs
@@ -7,7 +7,7 @@ namespace LibDescent.Tests
     [TestFixtureSource("TestData")]
     class Rl2XLTests
     {
-        private readonly D2Level level;
+        private readonly D2XXLLevel level;
 
         public static IEnumerable TestData
         {
@@ -15,12 +15,12 @@ namespace LibDescent.Tests
             {
                 // First case - test level (saved by DLE)
                 var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
-                var level = D2Level.CreateFromStream(hogFile.GetLumpAsStream("level3.rl2"));
+                var level = D2XXLLevel.CreateFromStream(hogFile.GetLumpAsStream("level3.rl2"));
                 yield return new TestFixtureData(level);
             }
         }
 
-        public Rl2XLTests(D2Level level)
+        public Rl2XLTests(D2XXLLevel level)
         {
             this.level = level;
         }

--- a/Tests/Rl2XLTests.cs
+++ b/Tests/Rl2XLTests.cs
@@ -1,0 +1,35 @@
+﻿using LibDescent.Data;
+using NUnit.Framework;
+using System.Collections;
+
+namespace LibDescent.Tests
+{
+    [TestFixtureSource("TestData")]
+    class Rl2XLTests
+    {
+        private readonly D2Level level;
+
+        public static IEnumerable TestData
+        {
+            get
+            {
+                // First case - test level (saved by DLE)
+                var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
+                var level = D2Level.CreateFromStream(hogFile.GetLumpAsStream("level3.rl2"));
+                yield return new TestFixtureData(level);
+            }
+        }
+
+        public Rl2XLTests(D2Level level)
+        {
+            this.level = level;
+        }
+
+        [Test]
+        public void TestLoadLevelSucceeds()
+        {
+            // Level already loaded by Setup, just check it's there
+            Assert.NotNull(level);
+        }
+    }
+}

--- a/Tests/Rl2XLTests.cs
+++ b/Tests/Rl2XLTests.cs
@@ -1,6 +1,7 @@
 ﻿using LibDescent.Data;
 using NUnit.Framework;
 using System.Collections;
+using System.IO;
 
 namespace LibDescent.Tests
 {
@@ -16,6 +17,15 @@ namespace LibDescent.Tests
                 // First case - test level (saved by DLE)
                 var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
                 var level = D2XXLLevel.CreateFromStream(hogFile.GetLumpAsStream("level3.rl2"));
+                yield return new TestFixtureData(level);
+
+                // Second case - output of D2XXLLevel.WriteToStream
+                using (var stream = new MemoryStream())
+                {
+                    level.WriteToStream(stream);
+                    stream.Seek(0, SeekOrigin.Begin);
+                    level = D2XXLLevel.CreateFromStream(stream);
+                }
                 yield return new TestFixtureData(level);
             }
         }


### PR DESCRIPTION
This allows LibDescent to load/save D2X-XL levels. It supports most XL level features, with a couple notable omissions:

1. Structures for special effects objects are preliminary and undocumented
2. Non-cubic segments are not supported yet