### PR TITLE
Level object refactor

### DIFF
--- a/Data/Level/ControlType.cs
+++ b/Data/Level/ControlType.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LibDescent.Data
+{
+    public abstract class ControlType
+    {
+        public abstract ControlTypeID Identifier { get; }
+    }
+
+    public class AIControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.AI;
+
+        public const int NumAIFlags = 11;
+        
+        public byte Behavior { get; set; }
+        public byte Flags { get; set; }
+        public byte[] AIFlags { get; } = new byte[NumAIFlags];
+        public short HideSegment { get; set; }
+        public short HideIndex { get; set; }
+        public short PathLength { get; set; }
+        public short CurPathIndex { get; set; }
+    }
+
+    //Hack for completeness
+    public class MorphControl : AIControl
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Morph;
+    }
+
+    public class ExplosionControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Explosion;
+
+        public Fix SpawnTime { get; set; }
+        public Fix DeleteTime { get; set; }
+        public short DeleteObject { get; set; }
+    }
+
+    public class PowerupControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Powerup;
+        public int count;
+    }
+}

--- a/Data/Level/ControlType.cs
+++ b/Data/Level/ControlType.cs
@@ -4,6 +4,47 @@ using System.Text;
 
 namespace LibDescent.Data
 {
+    public static class ControlTypeFactory
+    {
+        public static ControlType NewControlType(ControlTypeID id)
+        {
+            switch (id)
+            {
+                case ControlTypeID.AI:
+                    return new AIControl();
+                case ControlTypeID.Morph:
+                    return new MorphControl();
+                case ControlTypeID.Explosion:
+                    return new ExplosionControl();
+                case ControlTypeID.Flying:
+                    return new FlyingControl();
+                case ControlTypeID.Slew:
+                    return new SlewControl();
+                case ControlTypeID.Flythrough:
+                    return new FlythroughControl();
+                case ControlTypeID.Weapon:
+                    return new WeaponControl();
+                case ControlTypeID.RepairCen:
+                    return new RepairCenterControl();
+                case ControlTypeID.Debris:
+                    return new DebrisControl();
+                case ControlTypeID.Powerup:
+                    return new PowerupControl();
+                case ControlTypeID.Light:
+                    return new LightControl();
+                case ControlTypeID.ControlCenter:
+                    return new ControlCenterControl();
+                case ControlTypeID.Remote:
+                    return new RemoteControl();
+
+                case ControlTypeID.None:
+                    return new NullControl();
+
+            }
+            throw new ArgumentException("ControlTypeFactory::NewControlType: bad controltype");
+        }
+    }
+
     public abstract class ControlType
     {
         public abstract ControlTypeID Identifier { get; }
@@ -24,7 +65,7 @@ namespace LibDescent.Data
         public short CurPathIndex { get; set; }
     }
 
-    //Hack for completeness
+    //Hack for completeness. This can be used in level files but raises an Int3.
     public class MorphControl : AIControl
     {
         public override ControlTypeID Identifier => ControlTypeID.Morph;
@@ -42,6 +83,84 @@ namespace LibDescent.Data
     public class PowerupControl : ControlType
     {
         public override ControlTypeID Identifier => ControlTypeID.Powerup;
-        public int count;
+        public int Count { get; set; }
+    }
+
+    public class LightControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Light;
+
+        public Fix Intensity { get; set; }
+    }
+
+    public class WaypointControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Waypoint;
+
+        public int WaypointId { get; set; }
+        public int NextWaypointId { get; set; }
+        public int Speed { get; set; }
+    }
+
+    public class WeaponControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Weapon;
+
+        public short ParentType { get; set; }
+        public short ParentNum { get; set; }
+        public int ParentSig { get; set; }
+    }
+
+    //Empty control types
+    public class NullControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.None;
+    }
+
+    public class FlyingControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Flying;
+    }
+
+    public class SlewControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Slew;
+    }
+
+    /// <summary>
+    /// This control type is dummied and only included for completeness.
+    /// </summary>
+    public class FlythroughControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Flythrough;
+    }
+
+    /// <summary>
+    /// This control type is dummied and only included for completeness.
+    /// </summary>
+    public class RepairCenterControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.RepairCen;
+    }
+
+    /// <summary>
+    /// This control type is dummied and only included for completeness.
+    /// </summary>
+    public class DebrisControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Debris;
+    }
+
+    /// <summary>
+    /// This control type is not useful in level definitions and only included for completeness.
+    /// </summary>
+    public class RemoteControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.Remote;
+    }
+
+    public class ControlCenterControl : ControlType
+    {
+        public override ControlTypeID Identifier => ControlTypeID.ControlCenter;
     }
 }

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -559,7 +559,7 @@ namespace LibDescent.Data
         {
             var levelObject = new LevelObject();
             levelObject.Type = (ObjectType)reader.ReadSByte();
-            levelObject.ID = reader.ReadByte();
+            levelObject.SubtypeID = reader.ReadByte();
             levelObject.ControlType = ControlTypeFactory.NewControlType((ControlTypeID)reader.ReadByte());
             levelObject.MoveType = MovementTypeFactory.NewMovementType((MovementTypeID)reader.ReadByte());
             levelObject.RenderType = RenderTypeFactory.NewRenderType((RenderTypeID)reader.ReadByte());
@@ -635,9 +635,9 @@ namespace LibDescent.Data
                     waypoint.Speed = reader.ReadInt32();
                     // Fix IDs from old D2X-XL levels
                     const int WAYPOINT_ID = 3;
-                    if (levelObject.ID != WAYPOINT_ID)
+                    if (levelObject.SubtypeID != WAYPOINT_ID)
                     {
-                        levelObject.ID = WAYPOINT_ID;
+                        levelObject.SubtypeID = WAYPOINT_ID;
                     }
                     break;
             }
@@ -719,9 +719,9 @@ namespace LibDescent.Data
                     s.Enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
                     // Fix IDs from old D2X-XL levels
                     const int SOUND_ID = 2;
-                    if (levelObject.ID != SOUND_ID)
+                    if (levelObject.SubtypeID != SOUND_ID)
                     {
-                        levelObject.ID = SOUND_ID;
+                        levelObject.SubtypeID = SOUND_ID;
                     }
                     break;
             }
@@ -1830,7 +1830,7 @@ namespace LibDescent.Data
         private void WriteObject(BinaryWriter writer, LevelObject levelObject)
         {
             writer.Write((byte)levelObject.Type);
-            writer.Write(levelObject.ID);
+            writer.Write(levelObject.SubtypeID);
             writer.Write((byte)levelObject.ControlTypeID);
             writer.Write((byte)levelObject.MoveTypeID);
             writer.Write((byte)levelObject.RenderTypeID);

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -561,7 +561,7 @@ namespace LibDescent.Data
             levelObject.type = (ObjectType)reader.ReadSByte();
             levelObject.id = reader.ReadByte();
             levelObject.ControlType = ControlTypeFactory.NewControlType((ControlTypeID)reader.ReadByte());
-            levelObject.moveType = (MovementTypeID)reader.ReadByte();
+            levelObject.MoveType = MovementTypeFactory.NewMovementType((MovementTypeID)reader.ReadByte());
             levelObject.RenderType = RenderTypeFactory.NewRenderType((RenderTypeID)reader.ReadByte());
             levelObject.flags = reader.ReadByte();
             levelObject.MultiplayerOnly = (_fileInfo.version > 37) ? (reader.ReadByte() > 0) : false;
@@ -576,21 +576,21 @@ namespace LibDescent.Data
             levelObject.containsId = reader.ReadByte();
             levelObject.containsCount = reader.ReadByte();
 
-            switch (levelObject.moveType)
+            switch (levelObject.MoveType)
             {
-                case MovementTypeID.Physics:
-                    levelObject.physicsInfo.velocity = ReadFixVector(reader);
-                    levelObject.physicsInfo.thrust = ReadFixVector(reader);
-                    levelObject.physicsInfo.mass = new Fix(reader.ReadInt32());
-                    levelObject.physicsInfo.drag = new Fix(reader.ReadInt32());
-                    levelObject.physicsInfo.brakes = new Fix(reader.ReadInt32());
-                    levelObject.physicsInfo.angVel = ReadFixVector(reader);
-                    levelObject.physicsInfo.rotThrust = ReadFixVector(reader);
-                    levelObject.physicsInfo.turnroll = reader.ReadInt16();
-                    levelObject.physicsInfo.flags = reader.ReadInt16();
+                case PhysicsMoveType physics:
+                    physics.Velocity = ReadFixVector(reader);
+                    physics.Thrust = ReadFixVector(reader);
+                    physics.Mass = new Fix(reader.ReadInt32());
+                    physics.Drag = new Fix(reader.ReadInt32());
+                    physics.Brakes = new Fix(reader.ReadInt32());
+                    physics.AngularVel = ReadFixVector(reader);
+                    physics.RotationalThrust = ReadFixVector(reader);
+                    physics.Turnroll = reader.ReadInt16();
+                    physics.Flags = (PhysicsFlags)reader.ReadInt16();
                     break;
-                case MovementTypeID.Spinning:
-                    levelObject.spinRate = ReadFixVector(reader);
+                case SpinningMoveType spin:
+                    spin.SpinRate = ReadFixVector(reader);
                     break;
             }
             switch (levelObject.ControlType)
@@ -1832,7 +1832,7 @@ namespace LibDescent.Data
             writer.Write((byte)levelObject.type);
             writer.Write(levelObject.id);
             writer.Write((byte)levelObject.ControlTypeID);
-            writer.Write((byte)levelObject.moveType);
+            writer.Write((byte)levelObject.MoveTypeID);
             writer.Write((byte)levelObject.RenderTypeID);
             writer.Write(levelObject.flags);
             if (GameDataVersion > 37)
@@ -1849,21 +1849,21 @@ namespace LibDescent.Data
             writer.Write(levelObject.containsId);
             writer.Write(levelObject.containsCount);
 
-            switch (levelObject.moveType)
+            switch (levelObject.MoveType)
             {
-                case MovementTypeID.Physics:
-                    WriteFixVector(writer, levelObject.physicsInfo.velocity);
-                    WriteFixVector(writer, levelObject.physicsInfo.thrust);
-                    writer.Write(levelObject.physicsInfo.mass.value);
-                    writer.Write(levelObject.physicsInfo.drag.value);
-                    writer.Write(levelObject.physicsInfo.brakes.value);
-                    WriteFixVector(writer, levelObject.physicsInfo.angVel);
-                    WriteFixVector(writer, levelObject.physicsInfo.rotThrust);
-                    writer.Write(levelObject.physicsInfo.turnroll);
-                    writer.Write(levelObject.physicsInfo.flags);
+                case PhysicsMoveType physics:
+                    WriteFixVector(writer, physics.Velocity);
+                    WriteFixVector(writer, physics.Thrust);
+                    writer.Write(physics.Mass.value);
+                    writer.Write(physics.Drag.value);
+                    writer.Write(physics.Brakes.value);
+                    WriteFixVector(writer, physics.AngularVel);
+                    WriteFixVector(writer, physics.RotationalThrust);
+                    writer.Write(physics.Turnroll);
+                    writer.Write((short)physics.Flags);
                     break;
-                case MovementTypeID.Spinning:
-                    WriteFixVector(writer, levelObject.spinRate);
+                case SpinningMoveType spin:
+                    WriteFixVector(writer, spin.SpinRate);
                     break;
             }
             switch (levelObject.ControlType)

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -572,7 +572,7 @@ namespace LibDescent.Data
             levelObject.Size = new Fix(reader.ReadInt32());
             levelObject.Shields = new Fix(reader.ReadInt32());
             levelObject.LastPos = ReadFixVector(reader);
-            levelObject.ContainsType = reader.ReadByte();
+            levelObject.ContainsType = (ObjectType)reader.ReadByte();
             levelObject.ContainsId = reader.ReadByte();
             levelObject.ContainsCount = reader.ReadByte();
 
@@ -1845,7 +1845,7 @@ namespace LibDescent.Data
             writer.Write(levelObject.Size.value);
             writer.Write(levelObject.Shields.value);
             WriteFixVector(writer, levelObject.LastPos);
-            writer.Write(levelObject.ContainsType);
+            writer.Write((byte)levelObject.ContainsType);
             writer.Write(levelObject.ContainsId);
             writer.Write(levelObject.ContainsCount);
 

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -562,7 +562,7 @@ namespace LibDescent.Data
             levelObject.id = reader.ReadByte();
             levelObject.controlType = (ControlTypeID)reader.ReadByte();
             levelObject.moveType = (MovementTypeID)reader.ReadByte();
-            levelObject.renderType = (RenderTypeID)reader.ReadByte();
+            levelObject.RenderType = RenderTypeFactory.NewRenderType((RenderTypeID)reader.ReadByte());
             levelObject.flags = reader.ReadByte();
             levelObject.MultiplayerOnly = (_fileInfo.version > 37) ? (reader.ReadByte() > 0) : false;
             levelObject.segnum = reader.ReadInt16();
@@ -633,76 +633,85 @@ namespace LibDescent.Data
                     }
                     break;
             }
-            switch (levelObject.renderType)
+            switch (levelObject.RenderType)
             {
-                case RenderTypeID.Polyobj:
+                case PolymodelRenderType pm:
                     {
-                        levelObject.modelInfo.modelNum = reader.ReadInt32();
+                        pm.ModelNum = reader.ReadInt32();
                         for (int i = 0; i < Polymodel.MAX_SUBMODELS; i++)
                         {
-                            levelObject.modelInfo.animAngles[i] = ReadFixAngles(reader);
+                            pm.BodyAngles[i] = ReadFixAngles(reader);
                         }
-                        levelObject.modelInfo.flags = reader.ReadInt32();
-                        levelObject.modelInfo.textureOverride = reader.ReadInt32();
+                        pm.Flags = reader.ReadInt32();
+                        pm.TextureOverride = reader.ReadInt32();
                     }
                     break;
-                case RenderTypeID.WeaponVClip:
-                case RenderTypeID.Hostage:
-                case RenderTypeID.Powerup:
-                case RenderTypeID.Fireball:
-                    levelObject.spriteInfo.vclipNum = reader.ReadInt32();
-                    levelObject.spriteInfo.frameTime = new Fix(reader.ReadInt32());
-                    levelObject.spriteInfo.frameNumber = reader.ReadByte();
+                case FireballRenderType fb:
+                //case RenderTypeID.Hostage:
+                //case RenderTypeID.Powerup:
+                //case RenderTypeID.Fireball:
+                    fb.VClipNum = reader.ReadInt32();
+                    fb.FrameTime = new Fix(reader.ReadInt32());
+                    fb.FrameNumber = reader.ReadByte();
                     break;
-                case RenderTypeID.Particle:
-                    levelObject.particleInfo.nLife = reader.ReadInt32();
-                    levelObject.particleInfo.nSize = reader.ReadInt32();
-                    levelObject.particleInfo.nParts = reader.ReadInt32();
-                    levelObject.particleInfo.nSpeed = reader.ReadInt32();
-                    levelObject.particleInfo.nDrift = reader.ReadInt32();
-                    levelObject.particleInfo.nBrightness = reader.ReadInt32();
-                    levelObject.particleInfo.color.R = reader.ReadByte();
-                    levelObject.particleInfo.color.G = reader.ReadByte();
-                    levelObject.particleInfo.color.B = reader.ReadByte();
-                    levelObject.particleInfo.color.A = reader.ReadByte();
-                    levelObject.particleInfo.nSide = reader.ReadByte();
-                    // DLE used gamedata version, but that was probably a mistake (18 is pre-release D1).
-                    // Don't have a matching level to test with but level version is more likely to work
-                    levelObject.particleInfo.nType = (_levelVersion < 18) ? (byte)0 : reader.ReadByte();
-                    levelObject.particleInfo.enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
+                case ParticleRenderType p:
+                    {
+                        p.Life = reader.ReadInt32();
+                        p.Size = reader.ReadInt32();
+                        p.Parts = reader.ReadInt32();
+                        p.Speed = reader.ReadInt32();
+                        p.Drift = reader.ReadInt32();
+                        p.Brightness = reader.ReadInt32();
+                        //I love properties btw
+                        Color color = new Color();
+                        color.R = reader.ReadByte();
+                        color.G = reader.ReadByte();
+                        color.B = reader.ReadByte();
+                        color.A = reader.ReadByte();
+                        p.Color = color;
+                        p.Side = reader.ReadByte();
+                        // DLE used gamedata version, but that was probably a mistake (18 is pre-release D1).
+                        // Don't have a matching level to test with but level version is more likely to work
+                        p.Type = (_levelVersion < 18) ? (byte)0 : reader.ReadByte();
+                        p.Enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
+                    }
                     break;
-                case RenderTypeID.Lightning:
-                    levelObject.lightningInfo.nLife = reader.ReadInt32();
-                    levelObject.lightningInfo.nDelay = reader.ReadInt32();
-                    levelObject.lightningInfo.nLength = reader.ReadInt32();
-                    levelObject.lightningInfo.nAmplitude = reader.ReadInt32();
-                    levelObject.lightningInfo.nOffset = reader.ReadInt32();
-                    levelObject.lightningInfo.nWayPoint = (_levelVersion < 23) ? -1 : reader.ReadInt32();
-                    levelObject.lightningInfo.nBolts = reader.ReadInt16();
-                    levelObject.lightningInfo.nId = reader.ReadInt16();
-                    levelObject.lightningInfo.nTarget = reader.ReadInt16();
-                    levelObject.lightningInfo.nNodes = reader.ReadInt16();
-                    levelObject.lightningInfo.nChildren = reader.ReadInt16();
-                    levelObject.lightningInfo.nFrames = reader.ReadInt16();
-                    levelObject.lightningInfo.nWidth = (_levelVersion < 22) ? (byte)3 : reader.ReadByte();
-                    levelObject.lightningInfo.nAngle = reader.ReadByte();
-                    levelObject.lightningInfo.nStyle = reader.ReadByte();
-                    levelObject.lightningInfo.nSmoothe = reader.ReadByte();
-                    levelObject.lightningInfo.bClamp = reader.ReadByte();
-                    levelObject.lightningInfo.bPlasma = reader.ReadByte();
-                    levelObject.lightningInfo.bSound = reader.ReadByte();
-                    levelObject.lightningInfo.bRandom = reader.ReadByte();
-                    levelObject.lightningInfo.bInPlane = reader.ReadByte();
-                    levelObject.lightningInfo.color.R = reader.ReadByte();
-                    levelObject.lightningInfo.color.G = reader.ReadByte();
-                    levelObject.lightningInfo.color.B = reader.ReadByte();
-                    levelObject.lightningInfo.color.A = reader.ReadByte();
-                    levelObject.lightningInfo.enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
+                case LightningRenderType l:
+                    {
+                        l.Life = reader.ReadInt32();
+                        l.Delay = reader.ReadInt32();
+                        l.Length = reader.ReadInt32();
+                        l.Amplitude = reader.ReadInt32();
+                        l.Offset = reader.ReadInt32();
+                        l.WayPoint = (_levelVersion < 23) ? -1 : reader.ReadInt32();
+                        l.Bolts = reader.ReadInt16();
+                        l.Id = reader.ReadInt16();
+                        l.Target = reader.ReadInt16();
+                        l.Nodes = reader.ReadInt16();
+                        l.Children = reader.ReadInt16();
+                        l.Frames = reader.ReadInt16();
+                        l.Width = (_levelVersion < 22) ? (byte)3 : reader.ReadByte();
+                        l.Angle = reader.ReadByte();
+                        l.Style = reader.ReadByte();
+                        l.Smoothe = reader.ReadByte();
+                        l.Clamp = reader.ReadByte();
+                        l.Plasma = reader.ReadByte();
+                        l.Sound = reader.ReadByte();
+                        l.Random = reader.ReadByte();
+                        l.InPlane = reader.ReadByte();
+                        Color color = new Color();
+                        color.R = reader.ReadByte();
+                        color.G = reader.ReadByte();
+                        color.B = reader.ReadByte();
+                        color.A = reader.ReadByte();
+                        l.Color = color;
+                        l.Enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
+                    }
                     break;
-                case RenderTypeID.Sound:
-                    levelObject.soundInfo.filename = ReadString(reader, 40, false);
-                    levelObject.soundInfo.volume = reader.ReadInt32();
-                    levelObject.soundInfo.enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
+                case SoundRenderType s:
+                    s.Filename = ReadString(reader, 40, false);
+                    s.Volume = reader.ReadInt32();
+                    s.Enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
                     // Fix IDs from old D2X-XL levels
                     const int SOUND_ID = 2;
                     if (levelObject.id != SOUND_ID)
@@ -1819,7 +1828,7 @@ namespace LibDescent.Data
             writer.Write(levelObject.id);
             writer.Write((byte)levelObject.controlType);
             writer.Write((byte)levelObject.moveType);
-            writer.Write((byte)levelObject.renderType);
+            writer.Write((byte)levelObject.RenderTypeID);
             writer.Write(levelObject.flags);
             if (GameDataVersion > 37)
             {
@@ -1889,75 +1898,72 @@ namespace LibDescent.Data
                     writer.Write(levelObject.waypointInfo.speed);
                     break;
             }
-            switch (levelObject.renderType)
+            switch (levelObject.RenderType)
             {
-                case RenderTypeID.Polyobj:
+                case PolymodelRenderType pm:
                     {
-                        writer.Write(levelObject.modelInfo.modelNum);
+                        writer.Write(pm.ModelNum);
                         for (int i = 0; i < Polymodel.MAX_SUBMODELS; i++)
                         {
-                            WriteFixAngles(writer, levelObject.modelInfo.animAngles[i]);
+                            WriteFixAngles(writer, pm.BodyAngles[i]);
                         }
-                        writer.Write(levelObject.modelInfo.flags);
-                        writer.Write(levelObject.modelInfo.textureOverride);
+                        writer.Write(pm.Flags);
+                        writer.Write(pm.TextureOverride);
                     }
                     break;
-                case RenderTypeID.WeaponVClip:
-                case RenderTypeID.Hostage:
-                case RenderTypeID.Powerup:
-                case RenderTypeID.Fireball:
-                    writer.Write(levelObject.spriteInfo.vclipNum);
-                    writer.Write(levelObject.spriteInfo.frameTime.value);
-                    writer.Write(levelObject.spriteInfo.frameNumber);
+                case FireballRenderType fb:
+                    writer.Write(fb.VClipNum);
+                    writer.Write(fb.FrameTime.value);
+                    writer.Write(fb.FrameNumber);
                     break;
-                case RenderTypeID.Particle:
-                    writer.Write(levelObject.particleInfo.nLife);
-                    writer.Write(levelObject.particleInfo.nSize);
-                    writer.Write(levelObject.particleInfo.nParts);
-                    writer.Write(levelObject.particleInfo.nSpeed);
-                    writer.Write(levelObject.particleInfo.nDrift);
-                    writer.Write(levelObject.particleInfo.nBrightness);
-                    writer.Write((byte)levelObject.particleInfo.color.R);
-                    writer.Write((byte)levelObject.particleInfo.color.G);
-                    writer.Write((byte)levelObject.particleInfo.color.B);
-                    writer.Write((byte)levelObject.particleInfo.color.A);
-                    writer.Write(levelObject.particleInfo.nSide);
-                    writer.Write(levelObject.particleInfo.nType);
-                    writer.Write((byte)(levelObject.particleInfo.enabled ? 1 : 0));
+                case ParticleRenderType p:
+                    writer.Write(p.Life);
+                    writer.Write(p.Size);
+                    writer.Write(p.Parts);
+                    writer.Write(p.Speed);
+                    writer.Write(p.Drift);
+                    writer.Write(p.Brightness);
+                    writer.Write((byte)p.Color.R);
+                    writer.Write((byte)p.Color.G);
+                    writer.Write((byte)p.Color.B);
+                    writer.Write((byte)p.Color.A);
+                    writer.Write(p.Side);
+                    writer.Write(p.Type);
+                    writer.Write((byte)(p.Enabled ? 1 : 0));
                     break;
-                case RenderTypeID.Lightning:
-                    writer.Write(levelObject.lightningInfo.nLife);
-                    writer.Write(levelObject.lightningInfo.nDelay);
-                    writer.Write(levelObject.lightningInfo.nLength);
-                    writer.Write(levelObject.lightningInfo.nAmplitude);
-                    writer.Write(levelObject.lightningInfo.nOffset);
-                    writer.Write(levelObject.lightningInfo.nWayPoint);
-                    writer.Write(levelObject.lightningInfo.nBolts);
-                    writer.Write(levelObject.lightningInfo.nId);
-                    writer.Write(levelObject.lightningInfo.nTarget);
-                    writer.Write(levelObject.lightningInfo.nNodes);
-                    writer.Write(levelObject.lightningInfo.nChildren);
-                    writer.Write(levelObject.lightningInfo.nFrames);
-                    writer.Write(levelObject.lightningInfo.nWidth);
-                    writer.Write(levelObject.lightningInfo.nAngle);
-                    writer.Write(levelObject.lightningInfo.nStyle);
-                    writer.Write(levelObject.lightningInfo.nSmoothe);
-                    writer.Write(levelObject.lightningInfo.bClamp);
-                    writer.Write(levelObject.lightningInfo.bPlasma);
-                    writer.Write(levelObject.lightningInfo.bSound);
-                    writer.Write(levelObject.lightningInfo.bRandom);
-                    writer.Write(levelObject.lightningInfo.bInPlane);
-                    writer.Write((byte)levelObject.lightningInfo.color.R);
-                    writer.Write((byte)levelObject.lightningInfo.color.G);
-                    writer.Write((byte)levelObject.lightningInfo.color.B);
-                    writer.Write((byte)levelObject.lightningInfo.color.A);
-                    writer.Write((byte)(levelObject.lightningInfo.enabled ? 1 : 0));
+                case LightningRenderType l:
+                    writer.Write(l.Life);
+                    writer.Write(l.Delay);
+                    writer.Write(l.Length);
+                    writer.Write(l.Amplitude);
+                    writer.Write(l.Offset);
+                    writer.Write(l.WayPoint);
+                    writer.Write(l.Bolts);
+                    writer.Write(l.Id);
+                    writer.Write(l.Target);
+                    writer.Write(l.Nodes);
+                    writer.Write(l.Children);
+                    writer.Write(l.Frames);
+                    writer.Write(l.Width);
+                    writer.Write(l.Angle);
+                    writer.Write(l.Style);
+                    writer.Write(l.Smoothe);
+                    writer.Write(l.Clamp);
+                    writer.Write(l.Plasma);
+                    writer.Write(l.Sound);
+                    writer.Write(l.Random);
+                    writer.Write(l.InPlane);
+                    writer.Write((byte)l.Color.R);
+                    writer.Write((byte)l.Color.G);
+                    writer.Write((byte)l.Color.B);
+                    writer.Write((byte)l.Color.A);
+                    writer.Write((byte)(l.Enabled ? 1 : 0));
                     break;
-                case RenderTypeID.Sound:
-                    var soundFilename = EncodeString(levelObject.soundInfo.filename, 40, false);
+                case SoundRenderType s:
+                    var soundFilename = EncodeString(s.Filename, 40, false);
                     writer.Write(soundFilename);
-                    writer.Write(levelObject.soundInfo.volume);
-                    writer.Write((byte)(levelObject.soundInfo.enabled ? 1 : 0));
+                    writer.Write(s.Volume);
+                    writer.Write((byte)(s.Enabled ? 1 : 0));
                     break;
             }
         }

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -558,23 +558,23 @@ namespace LibDescent.Data
         private LevelObject ReadObject(BinaryReader reader)
         {
             var levelObject = new LevelObject();
-            levelObject.type = (ObjectType)reader.ReadSByte();
-            levelObject.id = reader.ReadByte();
+            levelObject.Type = (ObjectType)reader.ReadSByte();
+            levelObject.ID = reader.ReadByte();
             levelObject.ControlType = ControlTypeFactory.NewControlType((ControlTypeID)reader.ReadByte());
             levelObject.MoveType = MovementTypeFactory.NewMovementType((MovementTypeID)reader.ReadByte());
             levelObject.RenderType = RenderTypeFactory.NewRenderType((RenderTypeID)reader.ReadByte());
-            levelObject.flags = reader.ReadByte();
+            levelObject.Flags = reader.ReadByte();
             levelObject.MultiplayerOnly = (_fileInfo.version > 37) ? (reader.ReadByte() > 0) : false;
-            levelObject.segnum = reader.ReadInt16();
-            levelObject.attachedObject = -1;
-            levelObject.position = ReadFixVector(reader);
-            levelObject.orientation = ReadFixMatrix(reader);
-            levelObject.size = new Fix(reader.ReadInt32());
-            levelObject.shields = new Fix(reader.ReadInt32());
-            levelObject.lastPos = ReadFixVector(reader);
-            levelObject.containsType = reader.ReadByte();
-            levelObject.containsId = reader.ReadByte();
-            levelObject.containsCount = reader.ReadByte();
+            levelObject.Segnum = reader.ReadInt16();
+            levelObject.AttachedObject = -1;
+            levelObject.Position = ReadFixVector(reader);
+            levelObject.Orientation = ReadFixMatrix(reader);
+            levelObject.Size = new Fix(reader.ReadInt32());
+            levelObject.Shields = new Fix(reader.ReadInt32());
+            levelObject.LastPos = ReadFixVector(reader);
+            levelObject.ContainsType = reader.ReadByte();
+            levelObject.ContainsId = reader.ReadByte();
+            levelObject.ContainsCount = reader.ReadByte();
 
             switch (levelObject.MoveType)
             {
@@ -597,7 +597,7 @@ namespace LibDescent.Data
             {
                 case AIControl ai:
                     ai.Behavior = reader.ReadByte();
-                    for (int i = 0; i < AIInfo.NumAIFlags; i++)
+                    for (int i = 0; i < AIControl.NumAIFlags; i++)
                         ai.AIFlags[i] = reader.ReadByte();
 
                     ai.HideSegment = reader.ReadInt16();
@@ -635,9 +635,9 @@ namespace LibDescent.Data
                     waypoint.Speed = reader.ReadInt32();
                     // Fix IDs from old D2X-XL levels
                     const int WAYPOINT_ID = 3;
-                    if (levelObject.id != WAYPOINT_ID)
+                    if (levelObject.ID != WAYPOINT_ID)
                     {
-                        levelObject.id = WAYPOINT_ID;
+                        levelObject.ID = WAYPOINT_ID;
                     }
                     break;
             }
@@ -719,9 +719,9 @@ namespace LibDescent.Data
                     s.Enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
                     // Fix IDs from old D2X-XL levels
                     const int SOUND_ID = 2;
-                    if (levelObject.id != SOUND_ID)
+                    if (levelObject.ID != SOUND_ID)
                     {
-                        levelObject.id = SOUND_ID;
+                        levelObject.ID = SOUND_ID;
                     }
                     break;
             }
@@ -1829,25 +1829,25 @@ namespace LibDescent.Data
 
         private void WriteObject(BinaryWriter writer, LevelObject levelObject)
         {
-            writer.Write((byte)levelObject.type);
-            writer.Write(levelObject.id);
+            writer.Write((byte)levelObject.Type);
+            writer.Write(levelObject.ID);
             writer.Write((byte)levelObject.ControlTypeID);
             writer.Write((byte)levelObject.MoveTypeID);
             writer.Write((byte)levelObject.RenderTypeID);
-            writer.Write(levelObject.flags);
+            writer.Write(levelObject.Flags);
             if (GameDataVersion > 37)
             {
                 writer.Write((byte)(levelObject.MultiplayerOnly ? 1 : 0));
             }
-            writer.Write(levelObject.segnum);
-            WriteFixVector(writer, levelObject.position);
-            WriteFixMatrix(writer, levelObject.orientation);
-            writer.Write(levelObject.size.value);
-            writer.Write(levelObject.shields.value);
-            WriteFixVector(writer, levelObject.lastPos);
-            writer.Write(levelObject.containsType);
-            writer.Write(levelObject.containsId);
-            writer.Write(levelObject.containsCount);
+            writer.Write(levelObject.Segnum);
+            WriteFixVector(writer, levelObject.Position);
+            WriteFixMatrix(writer, levelObject.Orientation);
+            writer.Write(levelObject.Size.value);
+            writer.Write(levelObject.Shields.value);
+            WriteFixVector(writer, levelObject.LastPos);
+            writer.Write(levelObject.ContainsType);
+            writer.Write(levelObject.ContainsId);
+            writer.Write(levelObject.ContainsCount);
 
             switch (levelObject.MoveType)
             {
@@ -1870,7 +1870,7 @@ namespace LibDescent.Data
             {
                 case AIControl ai:
                     writer.Write(ai.Behavior);
-                    for (int i = 0; i < AIInfo.NumAIFlags; i++)
+                    for (int i = 0; i < AIControl.NumAIFlags; i++)
                         writer.Write(ai.AIFlags[i]);
 
                     writer.Write(ai.HideSegment);

--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -560,9 +560,9 @@ namespace LibDescent.Data
             var levelObject = new LevelObject();
             levelObject.type = (ObjectType)reader.ReadSByte();
             levelObject.id = reader.ReadByte();
-            levelObject.controlType = (ControlType)reader.ReadByte();
-            levelObject.moveType = (MovementType)reader.ReadByte();
-            levelObject.renderType = (RenderType)reader.ReadByte();
+            levelObject.controlType = (ControlTypeID)reader.ReadByte();
+            levelObject.moveType = (MovementTypeID)reader.ReadByte();
+            levelObject.renderType = (RenderTypeID)reader.ReadByte();
             levelObject.flags = reader.ReadByte();
             levelObject.MultiplayerOnly = (_fileInfo.version > 37) ? (reader.ReadByte() > 0) : false;
             levelObject.segnum = reader.ReadInt16();
@@ -578,7 +578,7 @@ namespace LibDescent.Data
 
             switch (levelObject.moveType)
             {
-                case MovementType.Physics:
+                case MovementTypeID.Physics:
                     levelObject.physicsInfo.velocity = ReadFixVector(reader);
                     levelObject.physicsInfo.thrust = ReadFixVector(reader);
                     levelObject.physicsInfo.mass = new Fix(reader.ReadInt32());
@@ -589,13 +589,13 @@ namespace LibDescent.Data
                     levelObject.physicsInfo.turnroll = reader.ReadInt16();
                     levelObject.physicsInfo.flags = reader.ReadInt16();
                     break;
-                case MovementType.Spinning:
+                case MovementTypeID.Spinning:
                     levelObject.spinRate = ReadFixVector(reader);
                     break;
             }
             switch (levelObject.controlType)
             {
-                case ControlType.AI:
+                case ControlTypeID.AI:
                     levelObject.aiInfo.behavior = reader.ReadByte();
                     for (int i = 0; i < AIInfo.NumAIFlags; i++)
                         levelObject.aiInfo.aiFlags[i] = reader.ReadByte();
@@ -610,18 +610,18 @@ namespace LibDescent.Data
                         reader.ReadInt32();
                     }
                     break;
-                case ControlType.Explosion:
+                case ControlTypeID.Explosion:
                     levelObject.explosionInfo.SpawnTime = new Fix(reader.ReadInt32());
                     levelObject.explosionInfo.DeleteTime = new Fix(reader.ReadInt32());
                     levelObject.explosionInfo.DeleteObject = reader.ReadInt16();
                     break;
-                case ControlType.Powerup:
+                case ControlTypeID.Powerup:
                     if (_fileInfo.version >= 25)
                     {
                         levelObject.powerupCount = reader.ReadInt32();
                     }
                     break;
-                case ControlType.Waypoint:
+                case ControlTypeID.Waypoint:
                     levelObject.waypointInfo.waypointId = reader.ReadInt32();
                     levelObject.waypointInfo.nextWaypointId = reader.ReadInt32();
                     levelObject.waypointInfo.speed = reader.ReadInt32();
@@ -635,7 +635,7 @@ namespace LibDescent.Data
             }
             switch (levelObject.renderType)
             {
-                case RenderType.Polyobj:
+                case RenderTypeID.Polyobj:
                     {
                         levelObject.modelInfo.modelNum = reader.ReadInt32();
                         for (int i = 0; i < Polymodel.MAX_SUBMODELS; i++)
@@ -646,15 +646,15 @@ namespace LibDescent.Data
                         levelObject.modelInfo.textureOverride = reader.ReadInt32();
                     }
                     break;
-                case RenderType.WeaponVClip:
-                case RenderType.Hostage:
-                case RenderType.Powerup:
-                case RenderType.Fireball:
+                case RenderTypeID.WeaponVClip:
+                case RenderTypeID.Hostage:
+                case RenderTypeID.Powerup:
+                case RenderTypeID.Fireball:
                     levelObject.spriteInfo.vclipNum = reader.ReadInt32();
                     levelObject.spriteInfo.frameTime = new Fix(reader.ReadInt32());
                     levelObject.spriteInfo.frameNumber = reader.ReadByte();
                     break;
-                case RenderType.Particle:
+                case RenderTypeID.Particle:
                     levelObject.particleInfo.nLife = reader.ReadInt32();
                     levelObject.particleInfo.nSize = reader.ReadInt32();
                     levelObject.particleInfo.nParts = reader.ReadInt32();
@@ -671,7 +671,7 @@ namespace LibDescent.Data
                     levelObject.particleInfo.nType = (_levelVersion < 18) ? (byte)0 : reader.ReadByte();
                     levelObject.particleInfo.enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
                     break;
-                case RenderType.Lightning:
+                case RenderTypeID.Lightning:
                     levelObject.lightningInfo.nLife = reader.ReadInt32();
                     levelObject.lightningInfo.nDelay = reader.ReadInt32();
                     levelObject.lightningInfo.nLength = reader.ReadInt32();
@@ -699,7 +699,7 @@ namespace LibDescent.Data
                     levelObject.lightningInfo.color.A = reader.ReadByte();
                     levelObject.lightningInfo.enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
                     break;
-                case RenderType.Sound:
+                case RenderTypeID.Sound:
                     levelObject.soundInfo.filename = ReadString(reader, 40, false);
                     levelObject.soundInfo.volume = reader.ReadInt32();
                     levelObject.soundInfo.enabled = (_levelVersion < 19) ? true : (reader.ReadSByte() > 0);
@@ -1837,7 +1837,7 @@ namespace LibDescent.Data
 
             switch (levelObject.moveType)
             {
-                case MovementType.Physics:
+                case MovementTypeID.Physics:
                     WriteFixVector(writer, levelObject.physicsInfo.velocity);
                     WriteFixVector(writer, levelObject.physicsInfo.thrust);
                     writer.Write(levelObject.physicsInfo.mass.value);
@@ -1848,13 +1848,13 @@ namespace LibDescent.Data
                     writer.Write(levelObject.physicsInfo.turnroll);
                     writer.Write(levelObject.physicsInfo.flags);
                     break;
-                case MovementType.Spinning:
+                case MovementTypeID.Spinning:
                     WriteFixVector(writer, levelObject.spinRate);
                     break;
             }
             switch (levelObject.controlType)
             {
-                case ControlType.AI:
+                case ControlTypeID.AI:
                     writer.Write(levelObject.aiInfo.behavior);
                     for (int i = 0; i < AIInfo.NumAIFlags; i++)
                         writer.Write(levelObject.aiInfo.aiFlags[i]);
@@ -1872,18 +1872,18 @@ namespace LibDescent.Data
                     }
 
                     break;
-                case ControlType.Explosion:
+                case ControlTypeID.Explosion:
                     writer.Write(levelObject.explosionInfo.SpawnTime.value);
                     writer.Write(levelObject.explosionInfo.DeleteTime.value);
                     writer.Write(levelObject.explosionInfo.DeleteObject);
                     break;
-                case ControlType.Powerup:
+                case ControlTypeID.Powerup:
                     if (GameDataVersion >= 25)
                     {
                         writer.Write(levelObject.powerupCount);
                     }
                     break;
-                case ControlType.Waypoint:
+                case ControlTypeID.Waypoint:
                     writer.Write(levelObject.waypointInfo.waypointId);
                     writer.Write(levelObject.waypointInfo.nextWaypointId);
                     writer.Write(levelObject.waypointInfo.speed);
@@ -1891,7 +1891,7 @@ namespace LibDescent.Data
             }
             switch (levelObject.renderType)
             {
-                case RenderType.Polyobj:
+                case RenderTypeID.Polyobj:
                     {
                         writer.Write(levelObject.modelInfo.modelNum);
                         for (int i = 0; i < Polymodel.MAX_SUBMODELS; i++)
@@ -1902,15 +1902,15 @@ namespace LibDescent.Data
                         writer.Write(levelObject.modelInfo.textureOverride);
                     }
                     break;
-                case RenderType.WeaponVClip:
-                case RenderType.Hostage:
-                case RenderType.Powerup:
-                case RenderType.Fireball:
+                case RenderTypeID.WeaponVClip:
+                case RenderTypeID.Hostage:
+                case RenderTypeID.Powerup:
+                case RenderTypeID.Fireball:
                     writer.Write(levelObject.spriteInfo.vclipNum);
                     writer.Write(levelObject.spriteInfo.frameTime.value);
                     writer.Write(levelObject.spriteInfo.frameNumber);
                     break;
-                case RenderType.Particle:
+                case RenderTypeID.Particle:
                     writer.Write(levelObject.particleInfo.nLife);
                     writer.Write(levelObject.particleInfo.nSize);
                     writer.Write(levelObject.particleInfo.nParts);
@@ -1925,7 +1925,7 @@ namespace LibDescent.Data
                     writer.Write(levelObject.particleInfo.nType);
                     writer.Write((byte)(levelObject.particleInfo.enabled ? 1 : 0));
                     break;
-                case RenderType.Lightning:
+                case RenderTypeID.Lightning:
                     writer.Write(levelObject.lightningInfo.nLife);
                     writer.Write(levelObject.lightningInfo.nDelay);
                     writer.Write(levelObject.lightningInfo.nLength);
@@ -1953,7 +1953,7 @@ namespace LibDescent.Data
                     writer.Write((byte)levelObject.lightningInfo.color.A);
                     writer.Write((byte)(levelObject.lightningInfo.enabled ? 1 : 0));
                     break;
-                case RenderType.Sound:
+                case RenderTypeID.Sound:
                     var soundFilename = EncodeString(levelObject.soundInfo.filename, 40, false);
                     writer.Write(soundFilename);
                     writer.Write(levelObject.soundInfo.volume);

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -227,7 +227,17 @@ namespace LibDescent.Data
 
         public ControlTypeID controlType;
         public MovementTypeID moveType;
-        public RenderTypeID renderType;
+        //public RenderTypeID renderType;
+        public RenderTypeID RenderTypeID
+        {
+            get
+            {
+                if (RenderType == null)
+                    return RenderTypeID.None;
+                return RenderType.Identifier;
+            }
+        }
+
         public byte flags;
 
         /// <summary>
@@ -254,12 +264,8 @@ namespace LibDescent.Data
         public ExplosionInfo explosionInfo = new ExplosionInfo();
         public int powerupCount;
         public WaypointInfo waypointInfo = new WaypointInfo();
-        public ParticleInfo particleInfo = new ParticleInfo();
-        public LightningInfo lightningInfo = new LightningInfo();
-        public SoundInfo soundInfo = new SoundInfo();
         //Render info
-        public PolymodelInfo modelInfo = new PolymodelInfo();
-        public SpriteInfo spriteInfo;
+        public RenderType RenderType { get; set; }
 
         public int sig;
 

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -110,7 +110,7 @@ namespace LibDescent.Data
         /// <summary>
         /// The ID of the object's subtype. Meaning is based on the value of Type.
         /// </summary>
-        public byte ID { get; set; }
+        public byte SubtypeID { get; set; }
 
         /// <summary>
         /// Gets the numeric ID of the current ControlType.

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -191,7 +191,7 @@ namespace LibDescent.Data
         /// <summary>
         /// The type of the object this object contains. Should either be Powerup (2) or Robot (7) if ContainsCount > 0. 
         /// </summary>
-        public byte ContainsType { get; set; }
+        public ObjectType ContainsType { get; set; }
         /// <summary>
         /// The ID of the subtype of the object this object contains. 
         /// </summary>

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -54,7 +54,7 @@ namespace LibDescent.Data
         Explosion, // D2X-XL
         Effect, // D2X-XL
     }
-    public enum ControlType
+    public enum ControlTypeID
     {
         None,
         AI,
@@ -76,14 +76,14 @@ namespace LibDescent.Data
         Waypoint, // D2X-XL
     }
 
-    public enum MovementType
+    public enum MovementTypeID
     {
         None = 0,
         Physics,
         Spinning = 3,
     }
 
-    public enum RenderType
+    public enum RenderTypeID
     {
         None,
         Polyobj,
@@ -225,9 +225,9 @@ namespace LibDescent.Data
         public ObjectType type;
         public byte id;
 
-        public ControlType controlType;
-        public MovementType moveType;
-        public RenderType renderType;
+        public ControlTypeID controlType;
+        public MovementTypeID moveType;
+        public RenderTypeID renderType;
         public byte flags;
 
         /// <summary>

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -225,9 +225,16 @@ namespace LibDescent.Data
         public ObjectType type;
         public byte id;
 
-        public ControlTypeID controlType;
-        public MovementTypeID moveType;
-        //public RenderTypeID renderType;
+        public ControlTypeID ControlTypeID
+        {
+            get
+            {
+                if (ControlType == null)
+                    return ControlTypeID.None;
+                return ControlType.Identifier;
+            }
+        }
+public MovementTypeID moveType;
         public RenderTypeID RenderTypeID
         {
             get
@@ -260,10 +267,7 @@ namespace LibDescent.Data
         public PhysicsInfo physicsInfo;
         public FixVector spinRate;
         //Control info
-        public AIInfo aiInfo = new AIInfo();
-        public ExplosionInfo explosionInfo = new ExplosionInfo();
-        public int powerupCount;
-        public WaypointInfo waypointInfo = new WaypointInfo();
+        public ControlType ControlType { get; set; }
         //Render info
         public RenderType RenderType { get; set; }
 

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -101,130 +101,20 @@ namespace LibDescent.Data
         Sound, // D2X-XL
     }
 
-    //Move info
-    public struct PhysicsInfo
-    {
-        public FixVector velocity;
-        public FixVector thrust;
-        public Fix mass;
-        public Fix drag;
-        public Fix brakes;
-        public FixVector angVel;
-        public FixVector rotThrust;
-        public short turnroll; //fixang
-        public short flags;
-    }
-
-    //Control info
-    //man wouldn't it be nice if you could have a small array in a struct
-    //I guess it doesn't matter much since we're not making a million of these each frame
-    public class AIInfo
-    {
-        public const int NumAIFlags = 11;
-        public byte behavior;
-        public byte flags;
-        public byte[] aiFlags = new byte[NumAIFlags];
-        public short hideSegment;
-        public short hideIndex;
-        public short pathLength;
-        public short curPathIndex;
-    }
-
-    public struct ExplosionInfo
-    {
-        public Fix SpawnTime;
-        public Fix DeleteTime;
-        public short DeleteObject;
-    }
-
-    public struct PowerupInfo
-    {
-        public int count;
-    }
-
-    // D2X-XL
-    public struct WaypointInfo
-    {
-        public int waypointId;
-        public int nextWaypointId;
-        public int speed;
-    }
-
-    // D2X-XL
-    public struct ParticleInfo
-    {
-        public int nLife;
-        // nSize is a 2-element array in DLE, but the second element isn't used...
-        // I guess that means we don't need it?
-        public int nSize;
-        public int nParts;
-        public int nSpeed;
-        public int nDrift;
-        public int nBrightness;
-        public Color color;
-        public byte nSide;
-        public byte nType;
-        public bool enabled;
-    }
-
-    // D2X-XL
-    public struct LightningInfo
-    {
-        public int nLife;
-        public int nDelay;
-        public int nLength;
-        public int nAmplitude;
-        public int nOffset;
-        public int nWayPoint;
-        public short nBolts;
-        public short nId;
-        public short nTarget;
-        public short nNodes;
-        public short nChildren;
-        public short nFrames;
-        public byte nWidth;
-        public byte nAngle;
-        public byte nStyle;
-        public byte nSmoothe;
-        public byte bClamp;
-        public byte bPlasma;
-        public byte bSound;
-        public byte bRandom;
-        public byte bInPlane;
-        public Color color;
-        public bool enabled;
-    }
-
-    // D2X-XL
-    public struct SoundInfo
-    {
-        public string filename;
-        // Expected range 0-10, indicates how loud the sound should be
-        public int volume;
-        public bool enabled;
-    }
-
-    //Render info
-    public class PolymodelInfo
-    {
-        public int modelNum;
-        public FixAngles[] animAngles = new FixAngles[Polymodel.MAX_SUBMODELS];
-        public int flags;
-        public int textureOverride;
-    }
-
-    public struct SpriteInfo
-    {
-        public int vclipNum;
-        public Fix frameTime;
-        public byte frameNumber;
-    }
-
     public class LevelObject
     {
-        public ObjectType type;
-        public byte id;
+        /// <summary>
+        /// The object's basic type.
+        /// </summary>
+        public ObjectType Type { get; set; }
+        /// <summary>
+        /// The ID of the object's subtype. Meaning is based on the value of Type.
+        /// </summary>
+        public byte ID { get; set; }
 
+        /// <summary>
+        /// Gets the numeric ID of the current ControlType.
+        /// </summary>
         public ControlTypeID ControlTypeID
         {
             get
@@ -234,6 +124,9 @@ namespace LibDescent.Data
                 return ControlType.Identifier;
             }
         }
+        /// <summary>
+        /// Gets the numeric ID of the current MoveType.
+        /// </summary>
         public MovementTypeID MoveTypeID
         {
             get
@@ -243,6 +136,9 @@ namespace LibDescent.Data
                 return MoveType.Identifier;
             }
         }
+        /// <summary>
+        /// Gets the numeric ID of the current RenderType.
+        /// </summary>
         public RenderTypeID RenderTypeID
         {
             get
@@ -253,32 +149,75 @@ namespace LibDescent.Data
             }
         }
 
-        public byte flags;
+        /// <summary>
+        /// Misc object flags. Not generally useful in level files.
+        /// </summary>
+        public byte Flags { get; set; }
 
         /// <summary>
         /// Indicates if this object is only present in multiplayer modes. D2X-XL only.
         /// </summary>
         public bool MultiplayerOnly { get; set; }
-        public short segnum;
-        public short attachedObject;
+        /// <summary>
+        /// Number of the segment containing this object.
+        /// </summary>
+        public short Segnum { get; set; }
+        /// <summary>
+        /// Number of the object this is attached to. Only useful for Fireball objects.
+        /// </summary>
+        public short AttachedObject { get; set; }
 
-        public FixVector position;
-        public FixMatrix orientation;
-        public Fix size;
-        public Fix shields;
-        public FixVector lastPos;
+        /// <summary>
+        /// The current position of the object.
+        /// </summary>
+        public FixVector Position { get; set; }
+        /// <summary>
+        /// The current orientation of the object.
+        /// </summary>
+        public FixMatrix Orientation { get; set; }
+        /// <summary>
+        /// Radius of the object's collision sphere, in map units.
+        /// </summary>
+        public Fix Size { get; set; }
+        /// <summary>
+        /// Amount of hit points the object has.
+        /// </summary>
+        public Fix Shields { get; set; }
+        /// <summary>
+        /// The position of the object in the previous frame.
+        /// </summary>
+        public FixVector LastPos { get; set; }
 
-        public byte containsType;
-        public byte containsId;
-        public byte containsCount;
-        //Move info
+        /// <summary>
+        /// The type of the object this object contains. Should either be Powerup (2) or Robot (7) if ContainsCount > 0. 
+        /// </summary>
+        public byte ContainsType { get; set; }
+        /// <summary>
+        /// The ID of the subtype of the object this object contains. 
+        /// </summary>
+        public byte ContainsId { get; set; }
+        /// <summary>
+        /// The amount of objects contained in this object. Set to 0 to use default drops.
+        /// </summary>
+        public byte ContainsCount { get; set; }
+        /// <summary>
+        /// The current movement type for this object.
+        /// </summary>
         public MovementType MoveType { get; set; }
-        //Control info
+        /// <summary>
+        /// The current control type for this object.
+        /// </summary>
         public ControlType ControlType { get; set; }
+        /// <summary>
+        /// The current render type for this object.
+        /// </summary>
         //Render info
         public RenderType RenderType { get; set; }
 
-        public int sig;
+        /// <summary>
+        /// The signature of this object, a unique value to disambiguate similar objects. (Unused in level files?)
+        /// </summary>
+        public int Signature { get; set; }
 
         /// <summary>
         /// The object trigger assigned to this object. D2X-XL only.

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -215,11 +215,6 @@ namespace LibDescent.Data
         public RenderType RenderType { get; set; }
 
         /// <summary>
-        /// The signature of this object, a unique value to disambiguate similar objects. (Unused in level files?)
-        /// </summary>
-        public int Signature { get; set; }
-
-        /// <summary>
         /// The object trigger assigned to this object. D2X-XL only.
         /// </summary>
         public D2XXLTrigger Trigger { get; set; }

--- a/Data/Level/LevelObject.cs
+++ b/Data/Level/LevelObject.cs
@@ -234,7 +234,15 @@ namespace LibDescent.Data
                 return ControlType.Identifier;
             }
         }
-public MovementTypeID moveType;
+        public MovementTypeID MoveTypeID
+        {
+            get
+            {
+                if (RenderType == null)
+                    return MovementTypeID.None;
+                return MoveType.Identifier;
+            }
+        }
         public RenderTypeID RenderTypeID
         {
             get
@@ -264,8 +272,7 @@ public MovementTypeID moveType;
         public byte containsId;
         public byte containsCount;
         //Move info
-        public PhysicsInfo physicsInfo;
-        public FixVector spinRate;
+        public MovementType MoveType { get; set; }
         //Control info
         public ControlType ControlType { get; set; }
         //Render info

--- a/Data/Level/MovementType.cs
+++ b/Data/Level/MovementType.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LibDescent.Data
+{
+    public abstract class MovementType
+    {
+        public abstract MovementTypeID Identifier { get; }
+    }
+
+    [Flags]
+    public enum PhysicsFlags
+    {
+        /// <summary>
+        /// roll when turning
+        /// </summary>
+        Turnroll = 0x01,
+        /// <summary>
+        /// level object with closest side
+        /// </summary>
+        Levelling = 0x02,
+        /// <summary>
+        /// bounce (not slide) when hit wall
+        /// </summary>
+        Bounce = 0x04,
+        /// <summary>
+        /// wiggle while flying (players only)
+        /// </summary>
+        Wiggle = 0x08,
+        /// <summary>
+        /// object sticks (stops moving) when hits wall
+        /// </summary>
+        Stick = 0x10,
+        /// <summary>
+        /// object keeps going even after it hits another object (eg, fusion cannon)
+        /// </summary>
+        Persistent = 0x20,
+        /// <summary>
+        /// this object uses its thrust
+        /// </summary>
+        UsesTHrust = 0x40
+    }
+
+    public class PhysicsMoveType : MovementType
+    {
+        public override MovementTypeID Identifier => MovementTypeID.Physics; 
+
+        public FixVector Velocity { get; set; }
+        public FixVector Thrust { get; set; }
+        public Fix Mass { get; set; }
+        public Fix Drag { get; set; }
+        public Fix Brakes { get; set; }
+        public FixVector AngularVel { get; set; }
+        public FixVector RotationalThrust { get; set; }
+        public short Turnroll { get; set; } //fixang
+        public PhysicsFlags Flags { get; set; }
+    }
+
+    public class SpinningMoveType : MovementType
+    {
+        public override MovementTypeID Identifier => MovementTypeID.Spinning;
+
+        public FixVector SpinRate { get; set; }
+    }
+}

--- a/Data/Level/MovementType.cs
+++ b/Data/Level/MovementType.cs
@@ -4,6 +4,23 @@ using System.Text;
 
 namespace LibDescent.Data
 {
+    public static class MovementTypeFactory
+    {
+        public static MovementType NewMovementType(MovementTypeID id)
+        {
+            switch (id)
+            {
+                case MovementTypeID.Physics:
+                    return new PhysicsMoveType();
+                case MovementTypeID.Spinning:
+                    return new SpinningMoveType();
+
+                case MovementTypeID.None:
+                    return new NullMovementType();
+            }
+            throw new ArgumentException("MovementTypeFactory::NewMovementType: bad movementtype");
+        }
+    }
     public abstract class MovementType
     {
         public abstract MovementTypeID Identifier { get; }
@@ -39,7 +56,7 @@ namespace LibDescent.Data
         /// <summary>
         /// this object uses its thrust
         /// </summary>
-        UsesTHrust = 0x40
+        UsesThrust = 0x40
     }
 
     public class PhysicsMoveType : MovementType
@@ -62,5 +79,10 @@ namespace LibDescent.Data
         public override MovementTypeID Identifier => MovementTypeID.Spinning;
 
         public FixVector SpinRate { get; set; }
+    }
+
+    public class NullMovementType : MovementType
+    {
+        public override MovementTypeID Identifier => MovementTypeID.None;
     }
 }

--- a/Data/Level/RenderType.cs
+++ b/Data/Level/RenderType.cs
@@ -1,4 +1,26 @@
-﻿using System;
+﻿/*
+    Copyright (c) 2019 The LibDescent Team
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,6 +29,48 @@ namespace LibDescent.Data
     public abstract class RenderType
     {
         public abstract RenderTypeID Identifier { get; }
+    }
+
+    //TODO: Make anything better than this mess
+    public static class RenderTypeFactory
+    {
+        public static RenderType NewRenderType(RenderTypeID identifer)
+        {
+            switch (identifer)
+            {
+                case RenderTypeID.Polyobj:
+                    return new PolymodelRenderType();
+                case RenderTypeID.Fireball:
+                    return new FireballRenderType();
+                case RenderTypeID.Laser:
+                    return new LaserRenderType();
+                case RenderTypeID.Hostage:
+                    return new HostageRenderType();
+                case RenderTypeID.Powerup:
+                    return new PowerupRenderType();
+                case RenderTypeID.Morph:
+                    return new MorphRenderType();
+                case RenderTypeID.WeaponVClip:
+                    return new WeaponVClipRenderType();
+                case RenderTypeID.Thruster:
+                    return new ThrusterRenderType();
+                case RenderTypeID.ExplosionBlast:
+                    return new ExplosionBlastRenderType();
+                case RenderTypeID.Shrapnel:
+                    return new ShrapnelRenderType();
+                case RenderTypeID.Particle:
+                    return new ParticleRenderType();
+                case RenderTypeID.Lightning:
+                    return new LightningRenderType();
+                case RenderTypeID.Sound:
+                    return new SoundRenderType();
+
+                case RenderTypeID.None:
+                    return new NullRenderType();
+            }
+
+            throw new ArgumentException("RenderTypeFactory::NewRenderType: bad rendertype");
+        }
     }
 
     public class PolymodelRenderType : RenderType
@@ -36,7 +100,70 @@ namespace LibDescent.Data
         public byte FrameNumber { get; set; }
     }
 
-    //This is annoying: Hostages and Weapon VClips use the same storage data, but are drawn differently
+    //D2X-XL
+    public class ParticleRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Particle;
+
+        public int Life { get; set; }
+        // nSize is a 2-element array in DLE, but the second element isn't used...
+        // I guess that means we don't need it?
+        public int Size { get; set; }
+        public int Parts { get; set; }
+        public int Speed { get; set; }
+        public int Drift { get; set; }
+        public int Brightness { get; set; }
+        public Color Color { get; set; }
+        public byte Side { get; set; }
+        public byte Type { get; set; }
+        public bool Enabled { get; set; }
+    }
+
+    //D2X-XL
+    public class LightningRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Lightning;
+
+        public int Life { get; set; }
+        public int Delay { get; set; }
+        public int Length { get; set; }
+        public int Amplitude { get; set; }
+        public int Offset { get; set; }
+        public int WayPoint { get; set; }
+        public short Bolts { get; set; }
+        public short Id { get; set; }
+        public short Target { get; set; }
+        public short Nodes { get; set; }
+        public short Children { get; set; }
+        public short Frames { get; set; }
+        public byte Width { get; set; }
+        public byte Angle { get; set; }
+        public byte Style { get; set; }
+        public byte Smoothe { get; set; }
+        public byte Clamp { get; set; }
+        public byte Plasma { get; set; }
+        public byte Sound { get; set; }
+        public byte Random { get; set; }
+        public byte InPlane { get; set; }
+        public Color Color { get; set; }
+        public bool Enabled { get; set; }
+    }
+
+    //D2X-XL
+    //What's this doing as a RenderType?
+    public class SoundRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Sound;
+
+        public string Filename { get; set; }
+        /// <summary>
+        /// Expected range 0-10, indicates how loud the sound should be
+        /// </summary>
+        public int Volume { get; set; }
+        public bool Enabled { get; set; }
+    }
+
+    //This is annoying: Hostages, Powerups, and Weapon VClips use the same storage data, but are drawn differently
     public class HostageRenderType : FireballRenderType
     {
         public override RenderTypeID Identifier => RenderTypeID.Hostage;
@@ -45,5 +172,35 @@ namespace LibDescent.Data
     public class WeaponVClipRenderType : FireballRenderType
     {
         public override RenderTypeID Identifier => RenderTypeID.WeaponVClip;
+    }
+
+    public class PowerupRenderType : FireballRenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Powerup;
+    }
+
+    //Empty render types
+    public class NullRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.None;
+    }
+    public class LaserRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Laser;
+    }
+
+    public class ThrusterRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Thruster;
+    }
+
+    public class ExplosionBlastRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.ExplosionBlast;
+    }
+
+    public class ShrapnelRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Shrapnel;
     }
 }

--- a/Data/Level/RenderType.cs
+++ b/Data/Level/RenderType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LibDescent.Data
+{
+    public abstract class RenderType
+    {
+        public abstract RenderTypeID Identifier { get; }
+    }
+
+    public class PolymodelRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Polyobj;
+
+        public int ModelNum { get; set; }
+        public FixAngles[] BodyAngles { get; } = new FixAngles[Polymodel.MAX_SUBMODELS];
+        /// <summary>
+        /// Specifies which subobjects to render. Set to 0 to make all of the model's submodels render.
+        /// </summary>
+        public int Flags { get; set; }
+        public int TextureOverride { get; set; }
+    }
+
+    public class MorphRenderType : PolymodelRenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Morph;
+    }
+
+    public class FireballRenderType : RenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Fireball;
+
+        public int VClipNum { get; set; }
+        public Fix FrameTime { get; set; }
+        public byte FrameNumber { get; set; }
+    }
+
+    //This is annoying: Hostages and Weapon VClips use the same storage data, but are drawn differently
+    public class HostageRenderType : FireballRenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.Hostage;
+    }
+
+    public class WeaponVClipRenderType : FireballRenderType
+    {
+        public override RenderTypeID Identifier => RenderTypeID.WeaponVClip;
+    }
+}

--- a/Data/Level/RenderType.cs
+++ b/Data/Level/RenderType.cs
@@ -106,7 +106,7 @@ namespace LibDescent.Data
         public override RenderTypeID Identifier => RenderTypeID.Particle;
 
         public int Life { get; set; }
-        // nSize is a 2-element array in DLE, but the second element isn't used...
+        // Size is a 2-element array in DLE, but the second element isn't used...
         // I guess that means we don't need it?
         public int Size { get; set; }
         public int Parts { get; set; }

--- a/Tests/LibDescent.Tests.csproj
+++ b/Tests/LibDescent.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -181,12 +181,13 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, level.Objects[0].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
             Assert.AreEqual(new FixVector(0, -10, -70), level.Objects[0].position);
             // Point directly forward
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
             Assert.AreEqual(expectedOrientation, level.Objects[0].orientation);
-            Assert.AreEqual(43, level.Objects[0].modelInfo.modelNum);
+            Assert.IsTrue(level.Objects[0].RenderType is PolymodelRenderType);
+            Assert.AreEqual(43, ((PolymodelRenderType)level.Objects[0].RenderType).ModelNum);
             Assert.AreEqual(0, level.Objects[0].segnum);
 
             // Powerup
@@ -194,7 +195,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(5, level.Objects[1].id); // red key
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].controlType);
-            Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].renderType);
+            Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].RenderTypeID);
             Assert.AreEqual(new FixVector(-80, -10, 10), level.Objects[1].position);
             Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
             Assert.AreEqual(11, level.Objects[1].segnum);
@@ -204,10 +205,11 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, level.Objects[2].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[2].moveType);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].RenderTypeID);
             Assert.AreEqual(new FixVector(40, -10, 50), level.Objects[2].position);
             Assert.AreEqual(expectedOrientation, level.Objects[2].orientation);
-            Assert.AreEqual(39, level.Objects[2].modelInfo.modelNum);
+            Assert.IsTrue(level.Objects[2].RenderType is PolymodelRenderType);
+            Assert.AreEqual(39, ((PolymodelRenderType)level.Objects[2].RenderType).ModelNum);
             Assert.AreEqual(14, level.Objects[2].segnum);
 
             // Hostage
@@ -215,10 +217,11 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, level.Objects[3].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].controlType);
-            Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].renderType);
+            Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
             Assert.AreEqual(new FixVector(80, -15, 10), level.Objects[3].position);
             Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
-            Assert.AreEqual(33, level.Objects[3].spriteInfo.vclipNum);
+            Assert.IsTrue(level.Objects[3].RenderType is HostageRenderType);
+            Assert.AreEqual(33, ((HostageRenderType)level.Objects[3].RenderType).VClipNum);
             Assert.AreEqual(15, level.Objects[3].segnum);
 
             // Robot
@@ -226,19 +229,18 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, level.Objects[4].id); // medium hulk
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].moveType);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[4].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].RenderTypeID);
             Assert.AreEqual(new FixVector(40, -10, -30), level.Objects[4].position);
             Assert.AreEqual(expectedOrientation, level.Objects[4].orientation);
             // Physics info seems to be blank, probably initialized from HAM/HXM data
             Assert.AreEqual((Fix)0, level.Objects[4].physicsInfo.mass);
             Assert.AreEqual((Fix)0, level.Objects[4].physicsInfo.drag);
             Assert.AreEqual(0, level.Objects[4].physicsInfo.flags);
-            // .shields should probably be a fix, will change that later
             Assert.AreEqual((Fix)100, level.Objects[4].shields);
             Assert.AreEqual(7, level.Objects[4].containsType); // powerup
             Assert.AreEqual(1, level.Objects[4].containsCount);
             Assert.AreEqual(11, level.Objects[4].containsId); // 4-pack conc
-            Assert.AreEqual(0, level.Objects[4].modelInfo.modelNum);
+            Assert.AreEqual(0, ((PolymodelRenderType)level.Objects[4].RenderType).ModelNum);
             Assert.AreEqual(16, level.Objects[4].segnum);
         }
 

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -177,71 +177,71 @@ namespace LibDescent.Tests
             Assert.AreEqual(5, level.Objects.Count);
 
             // Player
-            Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
-            Assert.AreEqual(0, level.Objects[0].id);
+            Assert.AreEqual(ObjectType.Player, level.Objects[0].Type);
+            Assert.AreEqual(0, level.Objects[0].ID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
-            Assert.AreEqual(new FixVector(0, -10, -70), level.Objects[0].position);
+            Assert.AreEqual(new FixVector(0, -10, -70), level.Objects[0].Position);
             // Point directly forward
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
-            Assert.AreEqual(expectedOrientation, level.Objects[0].orientation);
+            Assert.AreEqual(expectedOrientation, level.Objects[0].Orientation);
             Assert.IsTrue(level.Objects[0].RenderType is PolymodelRenderType);
             Assert.AreEqual(43, ((PolymodelRenderType)level.Objects[0].RenderType).ModelNum);
-            Assert.AreEqual(0, level.Objects[0].segnum);
+            Assert.AreEqual(0, level.Objects[0].Segnum);
 
             // Powerup
-            Assert.AreEqual(ObjectType.Powerup, level.Objects[1].type);
-            Assert.AreEqual(5, level.Objects[1].id); // red key
+            Assert.AreEqual(ObjectType.Powerup, level.Objects[1].Type);
+            Assert.AreEqual(5, level.Objects[1].ID); // red key
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].RenderTypeID);
-            Assert.AreEqual(new FixVector(-80, -10, 10), level.Objects[1].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
-            Assert.AreEqual(11, level.Objects[1].segnum);
+            Assert.AreEqual(new FixVector(-80, -10, 10), level.Objects[1].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[1].Orientation);
+            Assert.AreEqual(11, level.Objects[1].Segnum);
 
             // Reactor
-            Assert.AreEqual(ObjectType.ControlCenter, level.Objects[2].type);
-            Assert.AreEqual(0, level.Objects[2].id);
+            Assert.AreEqual(ObjectType.ControlCenter, level.Objects[2].Type);
+            Assert.AreEqual(0, level.Objects[2].ID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[2].MoveTypeID);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].RenderTypeID);
-            Assert.AreEqual(new FixVector(40, -10, 50), level.Objects[2].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[2].orientation);
+            Assert.AreEqual(new FixVector(40, -10, 50), level.Objects[2].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[2].Orientation);
             Assert.IsTrue(level.Objects[2].RenderType is PolymodelRenderType);
             Assert.AreEqual(39, ((PolymodelRenderType)level.Objects[2].RenderType).ModelNum);
-            Assert.AreEqual(14, level.Objects[2].segnum);
+            Assert.AreEqual(14, level.Objects[2].Segnum);
 
             // Hostage
-            Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
-            Assert.AreEqual(0, level.Objects[3].id);
+            Assert.AreEqual(ObjectType.Hostage, level.Objects[3].Type);
+            Assert.AreEqual(0, level.Objects[3].ID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
-            Assert.AreEqual(new FixVector(80, -15, 10), level.Objects[3].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
+            Assert.AreEqual(new FixVector(80, -15, 10), level.Objects[3].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[3].Orientation);
             Assert.IsTrue(level.Objects[3].RenderType is HostageRenderType);
             Assert.AreEqual(33, ((HostageRenderType)level.Objects[3].RenderType).VClipNum);
-            Assert.AreEqual(15, level.Objects[3].segnum);
+            Assert.AreEqual(15, level.Objects[3].Segnum);
 
             // Robot
-            Assert.AreEqual(ObjectType.Robot, level.Objects[4].type);
-            Assert.AreEqual(0, level.Objects[4].id); // medium hulk
+            Assert.AreEqual(ObjectType.Robot, level.Objects[4].Type);
+            Assert.AreEqual(0, level.Objects[4].ID); // medium hulk
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[4].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].RenderTypeID);
-            Assert.AreEqual(new FixVector(40, -10, -30), level.Objects[4].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[4].orientation);
+            Assert.AreEqual(new FixVector(40, -10, -30), level.Objects[4].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[4].Orientation);
             // Physics info seems to be blank, probably initialized from HAM/HXM data
             Assert.AreEqual((Fix)0, ((PhysicsMoveType)level.Objects[4].MoveType).Mass);
             Assert.AreEqual((Fix)0, ((PhysicsMoveType)level.Objects[4].MoveType).Drag);
             Assert.AreEqual((PhysicsFlags)0, ((PhysicsMoveType)level.Objects[4].MoveType).Flags);
-            Assert.AreEqual((Fix)100, level.Objects[4].shields);
-            Assert.AreEqual(7, level.Objects[4].containsType); // powerup
-            Assert.AreEqual(1, level.Objects[4].containsCount);
-            Assert.AreEqual(11, level.Objects[4].containsId); // 4-pack conc
+            Assert.AreEqual((Fix)100, level.Objects[4].Shields);
+            Assert.AreEqual(7, level.Objects[4].ContainsType); // powerup
+            Assert.AreEqual(1, level.Objects[4].ContainsCount);
+            Assert.AreEqual(11, level.Objects[4].ContainsId); // 4-pack conc
             Assert.AreEqual(0, ((PolymodelRenderType)level.Objects[4].RenderType).ModelNum);
-            Assert.AreEqual(16, level.Objects[4].segnum);
+            Assert.AreEqual(16, level.Objects[4].Segnum);
         }
 
         [Test]

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -180,7 +180,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
             Assert.AreEqual(0, level.Objects[0].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
-            Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].controlType);
+            Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
             Assert.AreEqual(new FixVector(0, -10, -70), level.Objects[0].position);
             // Point directly forward
@@ -194,7 +194,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Powerup, level.Objects[1].type);
             Assert.AreEqual(5, level.Objects[1].id); // red key
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
-            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].controlType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].RenderTypeID);
             Assert.AreEqual(new FixVector(-80, -10, 10), level.Objects[1].position);
             Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
@@ -204,7 +204,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[2].type);
             Assert.AreEqual(0, level.Objects[2].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[2].moveType);
-            Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].controlType);
+            Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].RenderTypeID);
             Assert.AreEqual(new FixVector(40, -10, 50), level.Objects[2].position);
             Assert.AreEqual(expectedOrientation, level.Objects[2].orientation);
@@ -216,7 +216,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
             Assert.AreEqual(0, level.Objects[3].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
-            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].controlType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
             Assert.AreEqual(new FixVector(80, -15, 10), level.Objects[3].position);
             Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
@@ -228,7 +228,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Robot, level.Objects[4].type);
             Assert.AreEqual(0, level.Objects[4].id); // medium hulk
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].moveType);
-            Assert.AreEqual(ControlTypeID.AI, level.Objects[4].controlType);
+            Assert.AreEqual(ControlTypeID.AI, level.Objects[4].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].RenderTypeID);
             Assert.AreEqual(new FixVector(40, -10, -30), level.Objects[4].position);
             Assert.AreEqual(expectedOrientation, level.Objects[4].orientation);

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -178,7 +178,7 @@ namespace LibDescent.Tests
 
             // Player
             Assert.AreEqual(ObjectType.Player, level.Objects[0].Type);
-            Assert.AreEqual(0, level.Objects[0].ID);
+            Assert.AreEqual(0, level.Objects[0].SubtypeID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
@@ -192,7 +192,7 @@ namespace LibDescent.Tests
 
             // Powerup
             Assert.AreEqual(ObjectType.Powerup, level.Objects[1].Type);
-            Assert.AreEqual(5, level.Objects[1].ID); // red key
+            Assert.AreEqual(5, level.Objects[1].SubtypeID); // red key
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].RenderTypeID);
@@ -202,7 +202,7 @@ namespace LibDescent.Tests
 
             // Reactor
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[2].Type);
-            Assert.AreEqual(0, level.Objects[2].ID);
+            Assert.AreEqual(0, level.Objects[2].SubtypeID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[2].MoveTypeID);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].RenderTypeID);
@@ -214,7 +214,7 @@ namespace LibDescent.Tests
 
             // Hostage
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].Type);
-            Assert.AreEqual(0, level.Objects[3].ID);
+            Assert.AreEqual(0, level.Objects[3].SubtypeID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
@@ -226,7 +226,7 @@ namespace LibDescent.Tests
 
             // Robot
             Assert.AreEqual(ObjectType.Robot, level.Objects[4].Type);
-            Assert.AreEqual(0, level.Objects[4].ID); // medium hulk
+            Assert.AreEqual(0, level.Objects[4].SubtypeID); // medium hulk
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[4].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].RenderTypeID);

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -179,9 +179,9 @@ namespace LibDescent.Tests
             // Player
             Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
             Assert.AreEqual(0, level.Objects[0].id);
-            Assert.AreEqual(MovementType.Physics, level.Objects[0].moveType);
-            Assert.AreEqual(ControlType.Slew, level.Objects[0].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[0].renderType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
+            Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].renderType);
             Assert.AreEqual(new FixVector(0, -10, -70), level.Objects[0].position);
             // Point directly forward
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
@@ -192,9 +192,9 @@ namespace LibDescent.Tests
             // Powerup
             Assert.AreEqual(ObjectType.Powerup, level.Objects[1].type);
             Assert.AreEqual(5, level.Objects[1].id); // red key
-            Assert.AreEqual(MovementType.None, level.Objects[1].moveType);
-            Assert.AreEqual(ControlType.Powerup, level.Objects[1].controlType);
-            Assert.AreEqual(RenderType.Powerup, level.Objects[1].renderType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].controlType);
+            Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].renderType);
             Assert.AreEqual(new FixVector(-80, -10, 10), level.Objects[1].position);
             Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
             Assert.AreEqual(11, level.Objects[1].segnum);
@@ -202,9 +202,9 @@ namespace LibDescent.Tests
             // Reactor
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[2].type);
             Assert.AreEqual(0, level.Objects[2].id);
-            Assert.AreEqual(MovementType.None, level.Objects[2].moveType);
-            Assert.AreEqual(ControlType.ControlCenter, level.Objects[2].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[2].renderType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[2].moveType);
+            Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].renderType);
             Assert.AreEqual(new FixVector(40, -10, 50), level.Objects[2].position);
             Assert.AreEqual(expectedOrientation, level.Objects[2].orientation);
             Assert.AreEqual(39, level.Objects[2].modelInfo.modelNum);
@@ -213,9 +213,9 @@ namespace LibDescent.Tests
             // Hostage
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
             Assert.AreEqual(0, level.Objects[3].id);
-            Assert.AreEqual(MovementType.None, level.Objects[3].moveType);
-            Assert.AreEqual(ControlType.Powerup, level.Objects[3].controlType);
-            Assert.AreEqual(RenderType.Hostage, level.Objects[3].renderType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].controlType);
+            Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].renderType);
             Assert.AreEqual(new FixVector(80, -15, 10), level.Objects[3].position);
             Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
             Assert.AreEqual(33, level.Objects[3].spriteInfo.vclipNum);
@@ -224,9 +224,9 @@ namespace LibDescent.Tests
             // Robot
             Assert.AreEqual(ObjectType.Robot, level.Objects[4].type);
             Assert.AreEqual(0, level.Objects[4].id); // medium hulk
-            Assert.AreEqual(MovementType.Physics, level.Objects[4].moveType);
-            Assert.AreEqual(ControlType.AI, level.Objects[4].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[4].renderType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].moveType);
+            Assert.AreEqual(ControlTypeID.AI, level.Objects[4].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].renderType);
             Assert.AreEqual(new FixVector(40, -10, -30), level.Objects[4].position);
             Assert.AreEqual(expectedOrientation, level.Objects[4].orientation);
             // Physics info seems to be blank, probably initialized from HAM/HXM data

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -179,7 +179,7 @@ namespace LibDescent.Tests
             // Player
             Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
             Assert.AreEqual(0, level.Objects[0].id);
-            Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
             Assert.AreEqual(new FixVector(0, -10, -70), level.Objects[0].position);
@@ -193,7 +193,7 @@ namespace LibDescent.Tests
             // Powerup
             Assert.AreEqual(ObjectType.Powerup, level.Objects[1].type);
             Assert.AreEqual(5, level.Objects[1].id); // red key
-            Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[1].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[1].RenderTypeID);
             Assert.AreEqual(new FixVector(-80, -10, 10), level.Objects[1].position);
@@ -203,7 +203,7 @@ namespace LibDescent.Tests
             // Reactor
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[2].type);
             Assert.AreEqual(0, level.Objects[2].id);
-            Assert.AreEqual(MovementTypeID.None, level.Objects[2].moveType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[2].MoveTypeID);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[2].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[2].RenderTypeID);
             Assert.AreEqual(new FixVector(40, -10, 50), level.Objects[2].position);
@@ -215,7 +215,7 @@ namespace LibDescent.Tests
             // Hostage
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
             Assert.AreEqual(0, level.Objects[3].id);
-            Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[3].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
             Assert.AreEqual(new FixVector(80, -15, 10), level.Objects[3].position);
@@ -227,15 +227,15 @@ namespace LibDescent.Tests
             // Robot
             Assert.AreEqual(ObjectType.Robot, level.Objects[4].type);
             Assert.AreEqual(0, level.Objects[4].id); // medium hulk
-            Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].moveType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[4].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[4].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[4].RenderTypeID);
             Assert.AreEqual(new FixVector(40, -10, -30), level.Objects[4].position);
             Assert.AreEqual(expectedOrientation, level.Objects[4].orientation);
             // Physics info seems to be blank, probably initialized from HAM/HXM data
-            Assert.AreEqual((Fix)0, level.Objects[4].physicsInfo.mass);
-            Assert.AreEqual((Fix)0, level.Objects[4].physicsInfo.drag);
-            Assert.AreEqual(0, level.Objects[4].physicsInfo.flags);
+            Assert.AreEqual((Fix)0, ((PhysicsMoveType)level.Objects[4].MoveType).Mass);
+            Assert.AreEqual((Fix)0, ((PhysicsMoveType)level.Objects[4].MoveType).Drag);
+            Assert.AreEqual((PhysicsFlags)0, ((PhysicsMoveType)level.Objects[4].MoveType).Flags);
             Assert.AreEqual((Fix)100, level.Objects[4].shields);
             Assert.AreEqual(7, level.Objects[4].containsType); // powerup
             Assert.AreEqual(1, level.Objects[4].containsCount);

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -237,7 +237,7 @@ namespace LibDescent.Tests
             Assert.AreEqual((Fix)0, ((PhysicsMoveType)level.Objects[4].MoveType).Drag);
             Assert.AreEqual((PhysicsFlags)0, ((PhysicsMoveType)level.Objects[4].MoveType).Flags);
             Assert.AreEqual((Fix)100, level.Objects[4].Shields);
-            Assert.AreEqual(7, level.Objects[4].ContainsType); // powerup
+            Assert.AreEqual((ObjectType)7, level.Objects[4].ContainsType); // powerup
             Assert.AreEqual(1, level.Objects[4].ContainsCount);
             Assert.AreEqual(11, level.Objects[4].ContainsId); // 4-pack conc
             Assert.AreEqual(0, ((PolymodelRenderType)level.Objects[4].RenderType).ModelNum);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -89,9 +89,9 @@ namespace LibDescent.Tests
             // Object 0 - player
             Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
             Assert.AreEqual(0, level.Objects[0].id);
-            Assert.AreEqual(MovementType.Physics, level.Objects[0].moveType);
-            Assert.AreEqual(ControlType.Slew, level.Objects[0].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[0].renderType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
+            Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].renderType);
             Assert.AreEqual(new FixVector(0, 0, 0), level.Objects[0].position);
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
             Assert.AreEqual(expectedOrientation, level.Objects[0].orientation);
@@ -101,9 +101,9 @@ namespace LibDescent.Tests
             // Object 1 - reactor
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[1].type);
             Assert.AreEqual(2, level.Objects[1].id);
-            Assert.AreEqual(MovementType.None, level.Objects[1].moveType);
-            Assert.AreEqual(ControlType.ControlCenter, level.Objects[1].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[1].renderType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
+            Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].renderType);
             Assert.AreEqual(new FixVector(50, -20, -95), level.Objects[1].position);
             Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
             Assert.AreEqual(97, level.Objects[1].modelInfo.modelNum);
@@ -112,9 +112,9 @@ namespace LibDescent.Tests
             // Object 3 - hostage
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
             Assert.AreEqual(0, level.Objects[3].id);
-            Assert.AreEqual(MovementType.None, level.Objects[3].moveType);
-            Assert.AreEqual(ControlType.Powerup, level.Objects[3].controlType);
-            Assert.AreEqual(RenderType.Hostage, level.Objects[3].renderType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].controlType);
+            Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].renderType);
             Assert.AreEqual(new FixVector(45, -65, 30), level.Objects[3].position);
             Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
             Assert.AreEqual(33, level.Objects[3].spriteInfo.vclipNum);
@@ -123,9 +123,9 @@ namespace LibDescent.Tests
             // Object 6 - co-op player
             Assert.AreEqual(ObjectType.Coop, level.Objects[6].type);
             Assert.AreEqual(8, level.Objects[6].id);
-            Assert.AreEqual(MovementType.Physics, level.Objects[6].moveType);
-            Assert.AreEqual(ControlType.None, level.Objects[6].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[6].renderType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].moveType);
+            Assert.AreEqual(ControlTypeID.None, level.Objects[6].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].renderType);
             Assert.AreEqual(new FixVector(20, 0, 40), level.Objects[6].position);
             expectedOrientation = new FixMatrix(new FixVector(0, 0, 1), new FixVector(0, 1, 0), new FixVector(-1, 0, 0));
             Assert.AreEqual(expectedOrientation, level.Objects[6].orientation);
@@ -135,9 +135,9 @@ namespace LibDescent.Tests
             // Object 9 - Guide-bot
             Assert.AreEqual(ObjectType.Robot, level.Objects[9].type);
             Assert.AreEqual(33, level.Objects[9].id);
-            Assert.AreEqual(MovementType.Physics, level.Objects[9].moveType);
-            Assert.AreEqual(ControlType.AI, level.Objects[9].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[9].renderType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].moveType);
+            Assert.AreEqual(ControlTypeID.AI, level.Objects[9].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].renderType);
             Assert.AreEqual(new FixVector(0, 30, 120), level.Objects[9].position);
             expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
             Assert.AreEqual(expectedOrientation, level.Objects[9].orientation);
@@ -147,9 +147,9 @@ namespace LibDescent.Tests
             // Object 21 - robot (Sidearm) with contained robots
             Assert.AreEqual(ObjectType.Robot, level.Objects[21].type);
             Assert.AreEqual(30, level.Objects[21].id);
-            Assert.AreEqual(MovementType.Physics, level.Objects[21].moveType);
-            Assert.AreEqual(ControlType.AI, level.Objects[21].controlType);
-            Assert.AreEqual(RenderType.Polyobj, level.Objects[21].renderType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].moveType);
+            Assert.AreEqual(ControlTypeID.AI, level.Objects[21].controlType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].renderType);
             Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].position);
             Assert.AreEqual(expectedOrientation, level.Objects[21].orientation);
             Assert.AreEqual((Fix)120, level.Objects[21].shields);
@@ -162,9 +162,9 @@ namespace LibDescent.Tests
             // Object 25 - blue flag
             Assert.AreEqual(ObjectType.Powerup, level.Objects[25].type);
             Assert.AreEqual(46, level.Objects[25].id);
-            Assert.AreEqual(MovementType.None, level.Objects[25].moveType);
-            Assert.AreEqual(ControlType.Powerup, level.Objects[25].controlType);
-            Assert.AreEqual(RenderType.Powerup, level.Objects[25].renderType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[25].moveType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].controlType);
+            Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].renderType);
             Assert.AreEqual(new FixVector(120, -20, 10), level.Objects[25].position);
             Assert.AreEqual(expectedOrientation, level.Objects[25].orientation);
             Assert.AreEqual(42, level.Objects[25].segnum);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -91,11 +91,11 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, level.Objects[0].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
             Assert.AreEqual(new FixVector(0, 0, 0), level.Objects[0].position);
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
             Assert.AreEqual(expectedOrientation, level.Objects[0].orientation);
-            Assert.AreEqual(108, level.Objects[0].modelInfo.modelNum);
+            Assert.AreEqual(108, ((PolymodelRenderType)level.Objects[0].RenderType).ModelNum);
             Assert.AreEqual(0, level.Objects[0].segnum);
 
             // Object 1 - reactor
@@ -103,10 +103,10 @@ namespace LibDescent.Tests
             Assert.AreEqual(2, level.Objects[1].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].RenderTypeID);
             Assert.AreEqual(new FixVector(50, -20, -95), level.Objects[1].position);
             Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
-            Assert.AreEqual(97, level.Objects[1].modelInfo.modelNum);
+            Assert.AreEqual(97, ((PolymodelRenderType)level.Objects[1].RenderType).ModelNum);
             Assert.AreEqual(74, level.Objects[1].segnum);
 
             // Object 3 - hostage
@@ -114,10 +114,10 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, level.Objects[3].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].controlType);
-            Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].renderType);
+            Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
             Assert.AreEqual(new FixVector(45, -65, 30), level.Objects[3].position);
             Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
-            Assert.AreEqual(33, level.Objects[3].spriteInfo.vclipNum);
+            Assert.AreEqual(33, ((HostageRenderType)level.Objects[3].RenderType).VClipNum);
             Assert.AreEqual(39, level.Objects[3].segnum);
 
             // Object 6 - co-op player
@@ -125,11 +125,11 @@ namespace LibDescent.Tests
             Assert.AreEqual(8, level.Objects[6].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].moveType);
             Assert.AreEqual(ControlTypeID.None, level.Objects[6].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].RenderTypeID);
             Assert.AreEqual(new FixVector(20, 0, 40), level.Objects[6].position);
             expectedOrientation = new FixMatrix(new FixVector(0, 0, 1), new FixVector(0, 1, 0), new FixVector(-1, 0, 0));
             Assert.AreEqual(expectedOrientation, level.Objects[6].orientation);
-            Assert.AreEqual(108, level.Objects[6].modelInfo.modelNum);
+            Assert.AreEqual(108, ((PolymodelRenderType)level.Objects[6].RenderType).ModelNum);
             Assert.AreEqual(5, level.Objects[6].segnum);
 
             // Object 9 - Guide-bot
@@ -137,11 +137,11 @@ namespace LibDescent.Tests
             Assert.AreEqual(33, level.Objects[9].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].moveType);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[9].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].RenderTypeID);
             Assert.AreEqual(new FixVector(0, 30, 120), level.Objects[9].position);
             expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
             Assert.AreEqual(expectedOrientation, level.Objects[9].orientation);
-            Assert.AreEqual(51, level.Objects[9].modelInfo.modelNum);
+            Assert.AreEqual(51, ((PolymodelRenderType)level.Objects[9].RenderType).ModelNum);
             Assert.AreEqual(15, level.Objects[9].segnum);
 
             // Object 21 - robot (Sidearm) with contained robots
@@ -149,14 +149,14 @@ namespace LibDescent.Tests
             Assert.AreEqual(30, level.Objects[21].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].moveType);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[21].controlType);
-            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].renderType);
+            Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].RenderTypeID);
             Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].position);
             Assert.AreEqual(expectedOrientation, level.Objects[21].orientation);
             Assert.AreEqual((Fix)120, level.Objects[21].shields);
             Assert.AreEqual(2, level.Objects[21].containsType); // robot
             Assert.AreEqual(4, level.Objects[21].containsCount);
             Assert.AreEqual(50, level.Objects[21].containsId); // sidearm modula
-            Assert.AreEqual(47, level.Objects[21].modelInfo.modelNum);
+            Assert.AreEqual(47, ((PolymodelRenderType)level.Objects[21].RenderType).ModelNum);
             Assert.AreEqual(61, level.Objects[21].segnum);
 
             // Object 25 - blue flag
@@ -164,7 +164,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(46, level.Objects[25].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[25].moveType);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].controlType);
-            Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].renderType);
+            Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].RenderTypeID);
             Assert.AreEqual(new FixVector(120, -20, 10), level.Objects[25].position);
             Assert.AreEqual(expectedOrientation, level.Objects[25].orientation);
             Assert.AreEqual(42, level.Objects[25].segnum);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -89,7 +89,7 @@ namespace LibDescent.Tests
             // Object 0 - player
             Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
             Assert.AreEqual(0, level.Objects[0].id);
-            Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
             Assert.AreEqual(new FixVector(0, 0, 0), level.Objects[0].position);
@@ -101,7 +101,7 @@ namespace LibDescent.Tests
             // Object 1 - reactor
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[1].type);
             Assert.AreEqual(2, level.Objects[1].id);
-            Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[1].MoveTypeID);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].RenderTypeID);
             Assert.AreEqual(new FixVector(50, -20, -95), level.Objects[1].position);
@@ -112,7 +112,7 @@ namespace LibDescent.Tests
             // Object 3 - hostage
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
             Assert.AreEqual(0, level.Objects[3].id);
-            Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[3].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
             Assert.AreEqual(new FixVector(45, -65, 30), level.Objects[3].position);
@@ -123,7 +123,7 @@ namespace LibDescent.Tests
             // Object 6 - co-op player
             Assert.AreEqual(ObjectType.Coop, level.Objects[6].type);
             Assert.AreEqual(8, level.Objects[6].id);
-            Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].moveType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].MoveTypeID);
             Assert.AreEqual(ControlTypeID.None, level.Objects[6].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].RenderTypeID);
             Assert.AreEqual(new FixVector(20, 0, 40), level.Objects[6].position);
@@ -135,7 +135,7 @@ namespace LibDescent.Tests
             // Object 9 - Guide-bot
             Assert.AreEqual(ObjectType.Robot, level.Objects[9].type);
             Assert.AreEqual(33, level.Objects[9].id);
-            Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].moveType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[9].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].RenderTypeID);
             Assert.AreEqual(new FixVector(0, 30, 120), level.Objects[9].position);
@@ -147,7 +147,7 @@ namespace LibDescent.Tests
             // Object 21 - robot (Sidearm) with contained robots
             Assert.AreEqual(ObjectType.Robot, level.Objects[21].type);
             Assert.AreEqual(30, level.Objects[21].id);
-            Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].moveType);
+            Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[21].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].RenderTypeID);
             Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].position);
@@ -162,7 +162,7 @@ namespace LibDescent.Tests
             // Object 25 - blue flag
             Assert.AreEqual(ObjectType.Powerup, level.Objects[25].type);
             Assert.AreEqual(46, level.Objects[25].id);
-            Assert.AreEqual(MovementTypeID.None, level.Objects[25].moveType);
+            Assert.AreEqual(MovementTypeID.None, level.Objects[25].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].RenderTypeID);
             Assert.AreEqual(new FixVector(120, -20, 10), level.Objects[25].position);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -88,7 +88,7 @@ namespace LibDescent.Tests
 
             // Object 0 - player
             Assert.AreEqual(ObjectType.Player, level.Objects[0].Type);
-            Assert.AreEqual(0, level.Objects[0].ID);
+            Assert.AreEqual(0, level.Objects[0].SubtypeID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
@@ -100,7 +100,7 @@ namespace LibDescent.Tests
 
             // Object 1 - reactor
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[1].Type);
-            Assert.AreEqual(2, level.Objects[1].ID);
+            Assert.AreEqual(2, level.Objects[1].SubtypeID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].MoveTypeID);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].RenderTypeID);
@@ -111,7 +111,7 @@ namespace LibDescent.Tests
 
             // Object 3 - hostage
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].Type);
-            Assert.AreEqual(0, level.Objects[3].ID);
+            Assert.AreEqual(0, level.Objects[3].SubtypeID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
@@ -122,7 +122,7 @@ namespace LibDescent.Tests
 
             // Object 6 - co-op player
             Assert.AreEqual(ObjectType.Coop, level.Objects[6].Type);
-            Assert.AreEqual(8, level.Objects[6].ID);
+            Assert.AreEqual(8, level.Objects[6].SubtypeID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].MoveTypeID);
             Assert.AreEqual(ControlTypeID.None, level.Objects[6].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].RenderTypeID);
@@ -134,7 +134,7 @@ namespace LibDescent.Tests
 
             // Object 9 - Guide-bot
             Assert.AreEqual(ObjectType.Robot, level.Objects[9].Type);
-            Assert.AreEqual(33, level.Objects[9].ID);
+            Assert.AreEqual(33, level.Objects[9].SubtypeID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[9].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].RenderTypeID);
@@ -146,7 +146,7 @@ namespace LibDescent.Tests
 
             // Object 21 - robot (Sidearm) with contained robots
             Assert.AreEqual(ObjectType.Robot, level.Objects[21].Type);
-            Assert.AreEqual(30, level.Objects[21].ID);
+            Assert.AreEqual(30, level.Objects[21].SubtypeID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[21].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].RenderTypeID);
@@ -161,7 +161,7 @@ namespace LibDescent.Tests
 
             // Object 25 - blue flag
             Assert.AreEqual(ObjectType.Powerup, level.Objects[25].Type);
-            Assert.AreEqual(46, level.Objects[25].ID);
+            Assert.AreEqual(46, level.Objects[25].SubtypeID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[25].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].RenderTypeID);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -87,87 +87,87 @@ namespace LibDescent.Tests
             Assert.AreEqual(28, level.Objects.Count);
 
             // Object 0 - player
-            Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
-            Assert.AreEqual(0, level.Objects[0].id);
+            Assert.AreEqual(ObjectType.Player, level.Objects[0].Type);
+            Assert.AreEqual(0, level.Objects[0].ID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
-            Assert.AreEqual(new FixVector(0, 0, 0), level.Objects[0].position);
+            Assert.AreEqual(new FixVector(0, 0, 0), level.Objects[0].Position);
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
-            Assert.AreEqual(expectedOrientation, level.Objects[0].orientation);
+            Assert.AreEqual(expectedOrientation, level.Objects[0].Orientation);
             Assert.AreEqual(108, ((PolymodelRenderType)level.Objects[0].RenderType).ModelNum);
-            Assert.AreEqual(0, level.Objects[0].segnum);
+            Assert.AreEqual(0, level.Objects[0].Segnum);
 
             // Object 1 - reactor
-            Assert.AreEqual(ObjectType.ControlCenter, level.Objects[1].type);
-            Assert.AreEqual(2, level.Objects[1].id);
+            Assert.AreEqual(ObjectType.ControlCenter, level.Objects[1].Type);
+            Assert.AreEqual(2, level.Objects[1].ID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].MoveTypeID);
             Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].RenderTypeID);
-            Assert.AreEqual(new FixVector(50, -20, -95), level.Objects[1].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
+            Assert.AreEqual(new FixVector(50, -20, -95), level.Objects[1].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[1].Orientation);
             Assert.AreEqual(97, ((PolymodelRenderType)level.Objects[1].RenderType).ModelNum);
-            Assert.AreEqual(74, level.Objects[1].segnum);
+            Assert.AreEqual(74, level.Objects[1].Segnum);
 
             // Object 3 - hostage
-            Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
-            Assert.AreEqual(0, level.Objects[3].id);
+            Assert.AreEqual(ObjectType.Hostage, level.Objects[3].Type);
+            Assert.AreEqual(0, level.Objects[3].ID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
-            Assert.AreEqual(new FixVector(45, -65, 30), level.Objects[3].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
+            Assert.AreEqual(new FixVector(45, -65, 30), level.Objects[3].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[3].Orientation);
             Assert.AreEqual(33, ((HostageRenderType)level.Objects[3].RenderType).VClipNum);
-            Assert.AreEqual(39, level.Objects[3].segnum);
+            Assert.AreEqual(39, level.Objects[3].Segnum);
 
             // Object 6 - co-op player
-            Assert.AreEqual(ObjectType.Coop, level.Objects[6].type);
-            Assert.AreEqual(8, level.Objects[6].id);
+            Assert.AreEqual(ObjectType.Coop, level.Objects[6].Type);
+            Assert.AreEqual(8, level.Objects[6].ID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].MoveTypeID);
             Assert.AreEqual(ControlTypeID.None, level.Objects[6].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].RenderTypeID);
-            Assert.AreEqual(new FixVector(20, 0, 40), level.Objects[6].position);
+            Assert.AreEqual(new FixVector(20, 0, 40), level.Objects[6].Position);
             expectedOrientation = new FixMatrix(new FixVector(0, 0, 1), new FixVector(0, 1, 0), new FixVector(-1, 0, 0));
-            Assert.AreEqual(expectedOrientation, level.Objects[6].orientation);
+            Assert.AreEqual(expectedOrientation, level.Objects[6].Orientation);
             Assert.AreEqual(108, ((PolymodelRenderType)level.Objects[6].RenderType).ModelNum);
-            Assert.AreEqual(5, level.Objects[6].segnum);
+            Assert.AreEqual(5, level.Objects[6].Segnum);
 
             // Object 9 - Guide-bot
-            Assert.AreEqual(ObjectType.Robot, level.Objects[9].type);
-            Assert.AreEqual(33, level.Objects[9].id);
+            Assert.AreEqual(ObjectType.Robot, level.Objects[9].Type);
+            Assert.AreEqual(33, level.Objects[9].ID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[9].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].RenderTypeID);
-            Assert.AreEqual(new FixVector(0, 30, 120), level.Objects[9].position);
+            Assert.AreEqual(new FixVector(0, 30, 120), level.Objects[9].Position);
             expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
-            Assert.AreEqual(expectedOrientation, level.Objects[9].orientation);
+            Assert.AreEqual(expectedOrientation, level.Objects[9].Orientation);
             Assert.AreEqual(51, ((PolymodelRenderType)level.Objects[9].RenderType).ModelNum);
-            Assert.AreEqual(15, level.Objects[9].segnum);
+            Assert.AreEqual(15, level.Objects[9].Segnum);
 
             // Object 21 - robot (Sidearm) with contained robots
-            Assert.AreEqual(ObjectType.Robot, level.Objects[21].type);
-            Assert.AreEqual(30, level.Objects[21].id);
+            Assert.AreEqual(ObjectType.Robot, level.Objects[21].Type);
+            Assert.AreEqual(30, level.Objects[21].ID);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].MoveTypeID);
             Assert.AreEqual(ControlTypeID.AI, level.Objects[21].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].RenderTypeID);
-            Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[21].orientation);
-            Assert.AreEqual((Fix)120, level.Objects[21].shields);
-            Assert.AreEqual(2, level.Objects[21].containsType); // robot
-            Assert.AreEqual(4, level.Objects[21].containsCount);
-            Assert.AreEqual(50, level.Objects[21].containsId); // sidearm modula
+            Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[21].Orientation);
+            Assert.AreEqual((Fix)120, level.Objects[21].Shields);
+            Assert.AreEqual(2, level.Objects[21].ContainsType); // robot
+            Assert.AreEqual(4, level.Objects[21].ContainsCount);
+            Assert.AreEqual(50, level.Objects[21].ContainsId); // sidearm modula
             Assert.AreEqual(47, ((PolymodelRenderType)level.Objects[21].RenderType).ModelNum);
-            Assert.AreEqual(61, level.Objects[21].segnum);
+            Assert.AreEqual(61, level.Objects[21].Segnum);
 
             // Object 25 - blue flag
-            Assert.AreEqual(ObjectType.Powerup, level.Objects[25].type);
-            Assert.AreEqual(46, level.Objects[25].id);
+            Assert.AreEqual(ObjectType.Powerup, level.Objects[25].Type);
+            Assert.AreEqual(46, level.Objects[25].ID);
             Assert.AreEqual(MovementTypeID.None, level.Objects[25].MoveTypeID);
             Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].RenderTypeID);
-            Assert.AreEqual(new FixVector(120, -20, 10), level.Objects[25].position);
-            Assert.AreEqual(expectedOrientation, level.Objects[25].orientation);
-            Assert.AreEqual(42, level.Objects[25].segnum);
+            Assert.AreEqual(new FixVector(120, -20, 10), level.Objects[25].Position);
+            Assert.AreEqual(expectedOrientation, level.Objects[25].Orientation);
+            Assert.AreEqual(42, level.Objects[25].Segnum);
         }
 
         [Test]

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -90,7 +90,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Player, level.Objects[0].type);
             Assert.AreEqual(0, level.Objects[0].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[0].moveType);
-            Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].controlType);
+            Assert.AreEqual(ControlTypeID.Slew, level.Objects[0].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[0].RenderTypeID);
             Assert.AreEqual(new FixVector(0, 0, 0), level.Objects[0].position);
             var expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
@@ -102,7 +102,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.ControlCenter, level.Objects[1].type);
             Assert.AreEqual(2, level.Objects[1].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[1].moveType);
-            Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].controlType);
+            Assert.AreEqual(ControlTypeID.ControlCenter, level.Objects[1].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[1].RenderTypeID);
             Assert.AreEqual(new FixVector(50, -20, -95), level.Objects[1].position);
             Assert.AreEqual(expectedOrientation, level.Objects[1].orientation);
@@ -113,7 +113,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Hostage, level.Objects[3].type);
             Assert.AreEqual(0, level.Objects[3].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[3].moveType);
-            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].controlType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[3].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Hostage, level.Objects[3].RenderTypeID);
             Assert.AreEqual(new FixVector(45, -65, 30), level.Objects[3].position);
             Assert.AreEqual(expectedOrientation, level.Objects[3].orientation);
@@ -124,7 +124,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Coop, level.Objects[6].type);
             Assert.AreEqual(8, level.Objects[6].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[6].moveType);
-            Assert.AreEqual(ControlTypeID.None, level.Objects[6].controlType);
+            Assert.AreEqual(ControlTypeID.None, level.Objects[6].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[6].RenderTypeID);
             Assert.AreEqual(new FixVector(20, 0, 40), level.Objects[6].position);
             expectedOrientation = new FixMatrix(new FixVector(0, 0, 1), new FixVector(0, 1, 0), new FixVector(-1, 0, 0));
@@ -136,7 +136,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Robot, level.Objects[9].type);
             Assert.AreEqual(33, level.Objects[9].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[9].moveType);
-            Assert.AreEqual(ControlTypeID.AI, level.Objects[9].controlType);
+            Assert.AreEqual(ControlTypeID.AI, level.Objects[9].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[9].RenderTypeID);
             Assert.AreEqual(new FixVector(0, 30, 120), level.Objects[9].position);
             expectedOrientation = new FixMatrix(new FixVector(1, 0, 0), new FixVector(0, 1, 0), new FixVector(0, 0, 1));
@@ -148,7 +148,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Robot, level.Objects[21].type);
             Assert.AreEqual(30, level.Objects[21].id);
             Assert.AreEqual(MovementTypeID.Physics, level.Objects[21].moveType);
-            Assert.AreEqual(ControlTypeID.AI, level.Objects[21].controlType);
+            Assert.AreEqual(ControlTypeID.AI, level.Objects[21].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Polyobj, level.Objects[21].RenderTypeID);
             Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].position);
             Assert.AreEqual(expectedOrientation, level.Objects[21].orientation);
@@ -163,7 +163,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(ObjectType.Powerup, level.Objects[25].type);
             Assert.AreEqual(46, level.Objects[25].id);
             Assert.AreEqual(MovementTypeID.None, level.Objects[25].moveType);
-            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].controlType);
+            Assert.AreEqual(ControlTypeID.Powerup, level.Objects[25].ControlTypeID);
             Assert.AreEqual(RenderTypeID.Powerup, level.Objects[25].RenderTypeID);
             Assert.AreEqual(new FixVector(120, -20, 10), level.Objects[25].position);
             Assert.AreEqual(expectedOrientation, level.Objects[25].orientation);

--- a/Tests/Rl2Tests.cs
+++ b/Tests/Rl2Tests.cs
@@ -153,7 +153,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(new FixVector(120, -20, -105), level.Objects[21].Position);
             Assert.AreEqual(expectedOrientation, level.Objects[21].Orientation);
             Assert.AreEqual((Fix)120, level.Objects[21].Shields);
-            Assert.AreEqual(2, level.Objects[21].ContainsType); // robot
+            Assert.AreEqual((ObjectType)2, level.Objects[21].ContainsType); // robot
             Assert.AreEqual(4, level.Objects[21].ContainsCount);
             Assert.AreEqual(50, level.Objects[21].ContainsId); // sidearm modula
             Assert.AreEqual(47, ((PolymodelRenderType)level.Objects[21].RenderType).ModelNum);


### PR DESCRIPTION
Refactors the LevelObject class to use properties and compact storage of MovementTypes, ControlTypes, and RenderTypes. 