### PR TITLE
Subtraction of the uv coordinates was the wrong way around.

### DIFF
--- a/Data/BSPTree.cs
+++ b/Data/BSPTree.cs
@@ -272,7 +272,7 @@ namespace LibDescent.Data
                     bool split = SplitEdge(vert1.Point, vert2.Point, planePoint, planeNorm, ref percentage, ref intersect);
                     if (split)
                     {
-                        Vector3 texDelta = vert1.UVs - vert2.UVs;
+                        Vector3 texDelta = vert2.UVs - vert1.UVs;
                         BSPVertex newVert = new BSPVertex
                         {
                             Classification = BSPClassification.OnPlane,


### PR DESCRIPTION
Subtraction of the uv coordinates was the wrong way around resulting in incorrect uv coordinates.