### PR TITLE
Store linked wall separately

### DIFF
--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -94,6 +94,7 @@ namespace LibDescent.Data
         private Dictionary<Side, uint> _sideWallLinks = new Dictionary<Side, uint>();
         private Dictionary<Segment, uint> _segmentMatcenLinks = new Dictionary<Segment, uint>();
         private Dictionary<Wall, byte> _wallTriggerLinks = new Dictionary<Wall, byte>();
+        private Dictionary<Wall, uint> _wallLinkedWalls = new Dictionary<Wall, uint>();
 
         protected abstract ILevel Level { get; }
 
@@ -454,7 +455,9 @@ namespace LibDescent.Data
 
                         Wall wall = new Wall(side);
                         wall.HitPoints = new Fix(reader.ReadInt32());
-                        _ = reader.ReadInt32(); // opposite wall - will recalculate
+                        var linkedWall = reader.ReadInt32();
+                        if (linkedWall != -1)
+                            _wallLinkedWalls[wall] = (uint)linkedWall;
                         wall.Type = (WallType)reader.ReadByte();
                         wall.Flags = (WallFlags)((_fileInfo.version < 37) ? reader.ReadByte() : reader.ReadUInt16());
                         wall.State = (WallState)reader.ReadByte();
@@ -469,6 +472,11 @@ namespace LibDescent.Data
                         wall.CloakOpacity = reader.ReadByte();
                         Level.Walls.Add(wall);
                     }
+                }
+
+                foreach (var wallLinkedWall in _wallLinkedWalls)
+                {
+                    wallLinkedWall.Key.LinkedWall = Level.Walls[(int)wallLinkedWall.Value];
                 }
 
                 foreach (var sideWallLink in _sideWallLinks)
@@ -1636,7 +1644,7 @@ namespace LibDescent.Data
                     writer.Write(Level.Segments.IndexOf(wall.Side.Segment));
                     writer.Write(wall.Side.SideNum);
                     writer.Write(wall.HitPoints.value);
-                    writer.Write(wall.OppositeWall != null ? Level.Walls.IndexOf(wall.OppositeWall) : -1);
+                    writer.Write(wall.LinkedWall != null ? Level.Walls.IndexOf(wall.LinkedWall) : -1);
                     writer.Write((byte)wall.Type);
                     if (GameDataVersion < 37)
                     {

--- a/Data/Level/Wall.cs
+++ b/Data/Level/Wall.cs
@@ -85,6 +85,7 @@ namespace LibDescent.Data
         public List<(ITrigger trigger, uint targetNum)> ControllingTriggers { get; } = new List<(ITrigger, uint)>();
 
         public Fix HitPoints { get; set; }
+        public Wall LinkedWall { get; set; }
         public WallFlags Flags { get; set; }
         public WallState State { get; set; }
         public byte DoorClipNumber { get; set; }

--- a/Tests/RdlTests.cs
+++ b/Tests/RdlTests.cs
@@ -258,6 +258,8 @@ namespace LibDescent.Tests
             Assert.AreEqual(WallFlags.DoorLocked, level.Walls[0].Flags);
             Assert.AreEqual(WallState.DoorClosed, level.Walls[0].State);
             Assert.AreEqual(WallKeyFlags.None, level.Walls[0].Keys);
+            Assert.IsNull(level.Walls[0].LinkedWall);
+            Assert.IsNull(level.Walls[1].LinkedWall);
 
             // Wall 2 is an energy center sparkle effect
             Assert.AreEqual(WallType.Illusion, level.Walls[2].Type);


### PR DESCRIPTION
A linked wall is different from the opposite wall, looks like it was intended for simultaneously opening doors.