### PR TITLE
Fix exceptions that were thrown when loading certain levels

### DIFF
--- a/Data/Level/Level.IO.cs
+++ b/Data/Level/Level.IO.cs
@@ -469,7 +469,7 @@ namespace LibDescent.Data
                         wall.DoorClipNumber = reader.ReadByte();
                         wall.Keys = (WallKeyFlags)reader.ReadByte();
                         _ = reader.ReadByte(); // controlling trigger - will recalculate
-                        wall.CloakOpacity = reader.ReadByte();
+                        wall.CloakOpacityClamped = reader.ReadByte();
                         Level.Walls.Add(wall);
                     }
                 }
@@ -524,6 +524,11 @@ namespace LibDescent.Data
 
                     for (int targetNum = 0; targetNum < numReactorTriggerTargets; targetNum++)
                     {
+                        // Some levels (e.g. Vertigo level 10) have reactor triggers pointing to
+                        // invalid targets, so we need to validate them first
+                        if (targets[targetNum].segmentNum < 0 || targets[targetNum].segmentNum >= Level.Segments.Count ||
+                            targets[targetNum].sideNum < 0 || targets[targetNum].sideNum >= Level.Segments[targets[targetNum].segmentNum].Sides.Length)
+                        { continue; }
                         var side = Level.Segments[targets[targetNum].segmentNum].Sides[targets[targetNum].sideNum];
                         Level.ReactorTriggerTargets.Add(side);
                     }

--- a/Data/Level/Wall.cs
+++ b/Data/Level/Wall.cs
@@ -106,6 +106,17 @@ namespace LibDescent.Data
                 cloakOpacity = value;
             }
         }
+        /// <summary>
+        /// Write-only version of CloakOpacity that clamps out-of-range inputs instead of throwing
+        /// an exception.
+        /// </summary>
+        public byte CloakOpacityClamped
+        {
+            set
+            {
+                CloakOpacity = (byte)(value > 31 ? 31 : value);
+            }
+        }
 
         #region Read-only convenience properties
         public Wall OppositeWall => Side?.GetJoinedSide()?.Wall;

--- a/Tests/MiscLevelLoadTests.cs
+++ b/Tests/MiscLevelLoadTests.cs
@@ -1,5 +1,6 @@
 ﻿using LibDescent.Data;
 using NUnit.Framework;
+using System.IO;
 
 namespace LibDescent.Tests
 {
@@ -51,6 +52,24 @@ namespace LibDescent.Tests
             ILevel level = LevelFactory.CreateFromStream(hogFile.GetLumpAsStream(6));
             Assert.NotNull(level);
             Assert.IsInstanceOf<D2XXLLevel>(level);
+        }
+
+        [Test]
+        [Ignore("Non-portable because filePath must be set manually; intended for debugging.")]
+        public void TestLoadAllLevelsFromHog()
+        {
+            string filePath = "";
+            using var stream = new FileStream(filePath.Replace("\"", null), FileMode.Open, FileAccess.Read);
+            var hogFile = new HOGFile(stream);
+            for (int i = 0; i < hogFile.Lumps.Count; i++)
+            {
+                if (hogFile.Lumps[i].Name.ToLower().EndsWith(".rdl") || hogFile.Lumps[i].Name.ToLower().EndsWith(".rl2"))
+                {
+                    using var levelStream = hogFile.GetLumpAsStream(i);
+                    var level = LevelFactory.CreateFromStream(levelStream);
+                    Assert.Greater(level.Segments.Count, 0);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I found that LibDescent failed to load a few levels I tried it on - Vertigo level 10 (because of an illegal reactor trigger) and Obsidian level 1 (because of an out-of-range cloak opacity value for a wall). Making some fixes for those issues here.