### PR TITLE
HOGFile refactor

### DIFF
--- a/Edit/EditorHOGFile.cs
+++ b/Edit/EditorHOGFile.cs
@@ -20,55 +20,44 @@
     SOFTWARE.
 */
 
+using LibDescent.Data;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using LibDescent.Data;
 
 namespace LibDescent.Edit
 {
     /// <summary>
     /// Represents a HOG file, a composite data file containing one or more lumps. 
     /// </summary>
-    public class EditorHOGFile
+    public class EditorHOGFile : HOGFile
     {
-        /// <summary>
-        /// Persistent stream to the HOG file, to allow loading lump data on demand.
-        /// </summary>
-        private BinaryReader fileStream;
-        /// <summary>
-        /// A list of all the HOG lumps.
-        /// </summary>
-        private readonly List<HOGLump> lumps = new List<HOGLump>();
         /// <summary>
         /// A map that allows look-up of HOG lumps based on filename.
         /// </summary>
-        private Dictionary<string, int> lumpNameMap = null;
+        /// <remarks>Acquire _lumpLock before accessing this field.</remarks>
+        private Dictionary<string, int> _lumpNameMap = null;
 
-        /// <summary>
-        /// The amount of lumps in the current HOG file.
-        /// </summary>
-        public int NumLumps { get { return lumps.Count; } }
         /// <summary>
         /// The current filename that the HOG file is read from and written to. 
         /// </summary>
         public string Filename { get; set; }
+
         /// <summary>
         /// The format that the HOG file is encoded with.
         /// </summary>
-        public HOGFormat Format { get; set; }
+        public new HOGFormat Format
+        {
+            get => base.Format;
 
-        /// <summary>
-        /// Collection of lumps, for iteration purposes.
-        /// </summary>
-        public ICollection<HOGLump> Lumps { get { return lumps; } }
-
-        // mutexes/locks. acquiring order: hogFileLock, lumpLock, lumpNameLock.
-        private readonly object hogFileLock = new object();      // used when accessing/modifying file stream
-        private readonly object lumpLock = new object();         // used when accessing/modifying lump list
-        private readonly object lumpNameLock = new object();     // used when accessing/modifying lump name map
+            set
+            {
+                // We need to rewrite and reopen the file when switching formats so that
+                // we don't corrupt the HOG
+                Write(Filename, value);
+            }
+        }
 
         public EditorHOGFile() { }
 
@@ -96,114 +85,24 @@ namespace LibDescent.Edit
         /// <param name="filename">The filename to read the HOG file from.</param>
         public void Read(string filename)
         {
-            Read(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read));
             Filename = filename;
-        }
-
-        /// <summary>
-        /// Reads the data of a HOG file from a stream.
-        /// </summary>
-        /// <param name="stream">The stream to read the HOG file from.</param>
-        public void Read(Stream stream)
-        {
-            lock (hogFileLock)
-                lock (lumpLock)
-                    lock (lumpNameLock)
-                    {
-                        BinaryReader br = new BinaryReader(stream);
-                        fileStream = br;
-                        lumps.Clear();
-
-                        char[] header = new char[3];
-                        header[0] = (char)br.ReadByte();
-                        header[1] = (char)br.ReadByte();
-                        header[2] = (char)br.ReadByte();
-
-                        var headerString = new string(header);
-                        switch (headerString)
-                        {
-                            case "DHF":
-                                Format = HOGFormat.Standard;
-                                break;
-                            case "D2X":
-                                Format = HOGFormat.D2X_XL;
-                                break;
-                            default:
-                                throw new InvalidDataException($"Unrecognized HOG header \"{headerString}\"");
-                        }
-
-                        try
-                        {
-                            while (true)
-                            {
-                                char[] filenamedata = new char[13];
-                                bool hashitnull = false;
-                                for (int x = 0; x < 13; x++)
-                                {
-                                    char c = (char)br.ReadByte();
-                                    if (c == 0)
-                                    {
-                                        hashitnull = true;
-                                    }
-                                    if (!hashitnull)
-                                    {
-                                        filenamedata[x] = c;
-                                    }
-                                }
-                                string filename = new string(filenamedata);
-                                filename = filename.Trim(' ', '\0');
-                                int filesize = br.ReadInt32();
-                                if (Format == HOGFormat.D2X_XL && filesize < 0)
-                                {
-                                    // D2X-XL format encodes "extended" lump headers with negative file sizes
-                                    filesize = -filesize;
-
-                                    string longFilename = Encoding.ASCII.GetString(br.ReadBytes(256));
-                                    if (longFilename.Contains("\0"))
-                                    {
-                                        longFilename = longFilename.Remove(longFilename.IndexOf('\0'));
-                                    }
-                                    longFilename = longFilename.Trim(' ');
-                                    // No real reason to use short filename in this instance; just replace it
-                                    filename = longFilename;
-                                }
-                                int offset = (int)br.BaseStream.Position;
-                                br.BaseStream.Seek(filesize, SeekOrigin.Current); //I hate hog files. Wads are cooler..
-
-                                HOGLump lump = new HOGLump(filename, filesize, offset);
-                                lumps.Add(lump);
-                            }
-                        }
-                        catch (EndOfStreamException)
-                        {
-                            //we got all the files
-                            //heh
-                            //i love hog
-                            byte[] data;
-                            for (int i = 0; i < NumLumps; i++)
-                            {
-                                data = GetLumpData(i);
-                                lumps[i].Type = HOGLump.IdentifyLump(lumps[i].Name, data);
-                            }
-                        }
-                    }
+            Read(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read));
         }
 
         private void RebuildLumpNameMap()
         {
-            lock (lumpLock)
-                lock (lumpNameLock)
+            lock (_lumpLock)
+            {
+                _lumpNameMap = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
+                for (int i = 0; i < NumLumps; i++)
                 {
-                    lumpNameMap = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
-                    for (int i = 0; i < NumLumps; i++)
+                    // In case of duplicates, first entry takes precedence
+                    if (!_lumpNameMap.ContainsKey(Lumps[i].Name))
                     {
-                        // In case of duplicates, first entry takes precedence
-                        if (!lumpNameMap.ContainsKey(lumps[i].Name))
-                        {
-                            lumpNameMap[lumps[i].Name] = i;
-                        }
+                        _lumpNameMap[Lumps[i].Name] = i;
                     }
                 }
+            }
         }
 
         /// <summary>
@@ -220,25 +119,33 @@ namespace LibDescent.Edit
         }
 
         /// <summary>
-        /// Writes the current contents of the HOG file to a file with the given filename.
+        /// Writes the current contents of the HOG file to a file with the given filename, then
+        /// uses that file as the new source.
         /// </summary>
         /// <param name="filename">The filename to write the HOG file to.</param>
-        public void Write(string filename)
+        public override void Write(string filename)
         {
-            lock (hogFileLock)
+            Write(filename, Format);
+        }
+
+        /// <summary>
+        /// Writes the current contents of the HOG file to a file with the given filename, then
+        /// uses that file as the new source.
+        /// </summary>
+        /// <param name="filename">The filename to write the HOG file to.</param>
+        /// <param name="format">The format to write the HOG file in.</param>
+        public override void Write(string filename, HOGFormat format)
+        {
+            lock (_hogFileLock)
             {
                 string tempFilename = Path.ChangeExtension(filename, ".newtmp");
                 using (var stream = File.Open(tempFilename, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
                 {
-                    Write(stream);
+                    Write(stream, format);
                 }
 
                 //Dispose of the old stream, and open up the new file as the read stream
-                if (fileStream != null)
-                {
-                    fileStream.Close();
-                    fileStream.Dispose();
-                }
+                Close();
 
                 if (File.Exists(filename))
                 {
@@ -254,64 +161,10 @@ namespace LibDescent.Edit
                 }
                 File.Move(tempFilename, filename);
 
-                fileStream = new BinaryReader(File.Open(filename, FileMode.Open, FileAccess.Read, FileShare.Read));
-                Filename = filename;
+                // Simpler to reopen the file than make a duplicate Write() method that updates
+                // offsets etc
+                Read(filename);
             }
-        }
-
-        /// <summary>
-        /// Writes the current contents of the HOG file to the given stream.
-        /// </summary>
-        /// <param name="stream">The stream to write the HOG file to.</param>
-        public void Write(Stream stream)
-        {
-            lock (hogFileLock)
-                lock (lumpLock)
-                    lock (lumpNameLock)
-                    {
-                        BinaryWriter bw = new BinaryWriter(stream, Encoding.Default, true);
-
-                        string headerString = (Format == HOGFormat.Standard) ? "DHF" : "D2X";
-                        foreach (char character in headerString)
-                        {
-                            bw.Write((byte)character);
-                        }
-
-                        HOGLump lump;
-                        for (int i = 0; i < lumps.Count; i++)
-                        {
-                            lump = lumps[i];
-                            for (int c = 0; c < 13; c++)
-                            {
-                                if (c < lump.Name.Length)
-                                    bw.Write((byte)lump.Name[c]);
-                                else
-                                    bw.Write((byte)0);
-                            }
-                            if (Format == HOGFormat.Standard || lump.Name.Length <= 13)
-                            {
-                                bw.Write(lump.Size);
-                            }
-                            else // D2X-XL with long filename
-                            {
-                                bw.Write(-lump.Size);
-                                var longFilenameBuffer = new byte[256]; // automatically zero-initialized
-                                                                        // Cut off the last character if needed to ensure null-termination
-                                Encoding.ASCII.GetBytes(lump.Name.Substring(0, Math.Min(lump.Name.Length, 255)))
-                                    .CopyTo(longFilenameBuffer, 0);
-                                bw.Write(longFilenameBuffer);
-                            }
-                            if (lump.Offset == -1) //This lump has cached data
-                                bw.Write(lump.Data);
-                            else //This lump doesn't have cached data, and instead needs to be read from the old stream
-                            {
-                                byte[] data = GetLumpData(i);
-                                bw.Write(data);
-                            }
-                            lump.Offset = (int)bw.BaseStream.Position - lump.Size; //Update the offset for the new file
-                        }
-                        bw.Flush();
-                    }
         }
 
         /// <summary>
@@ -319,21 +172,20 @@ namespace LibDescent.Edit
         /// </summary>
         /// <param name="filename">The filename to find.</param>
         /// <returns>The number of the lump if it exists, or -1 if it does not exist.</returns>
-        public int GetLumpNum(string filename)
+        public new int GetLumpNum(string filename)
         {
-            lock (lumpLock)
-                lock (lumpNameLock)
+            lock (_lumpLock)
+            {
+                if (_lumpNameMap == null)
                 {
-                    if (lumpNameMap == null)
-                    {
-                        RebuildLumpNameMap();
-                    }
-                    if (!lumpNameMap.TryGetValue(filename, out int index))
-                    {
-                        return -1;
-                    }
-                    return index;
+                    RebuildLumpNameMap();
                 }
+                if (!_lumpNameMap.TryGetValue(filename, out int index))
+                {
+                    return -1;
+                }
+                return index;
+            }
         }
 
         /// <summary>
@@ -343,10 +195,10 @@ namespace LibDescent.Edit
         /// <returns>The lump header.</returns>
         public HOGLump GetLumpHeader(int id)
         {
-            lock (lumpLock)
+            lock (_lumpLock)
             {
-                if (id < 0 || id >= lumps.Count) return null;
-                return lumps[id];
+                if (id < 0 || id >= Lumps.Count) return null;
+                return Lumps[id];
             }
         }
 
@@ -365,79 +217,33 @@ namespace LibDescent.Edit
         /// </summary>
         public void Close()
         {
-            lock (hogFileLock)
+            lock (_hogFileLock)
             {
-                if (fileStream != null)
+                if (_fileStream != null)
                 {
-                    fileStream.Close();
-                    fileStream.Dispose();
-                    fileStream = null;
+                    _fileStream.Close();
+                    _fileStream.Dispose();
+                    _fileStream = null;
                 }
             }
         }
 
-        private void CheckFileStreamNotNull()
+        protected override void CheckFileStreamNotNull()
         {
-            lock (hogFileLock)
+            lock (_hogFileLock)
             {
-                if (fileStream == null && Filename != null)
-                    fileStream = new BinaryReader(File.Open(Filename, FileMode.Open, FileAccess.Read, FileShare.Read));
-            }
-        }
-
-        /// <summary>
-        /// Gets the raw data of a given lump.
-        /// </summary>
-        /// <param name="id">The number of the lump to get the data of.</param>
-        /// <returns>A byte[] array of the lump's data.</returns>
-        public byte[] GetLumpData(int id)
-        {
-            lock (hogFileLock)
-                lock (lumpLock)
+                if (_fileStream == null)
                 {
-                    if (id < 0 || id >= lumps.Count) return null;
-                    if (lumps[id].Data != null)
-                        return lumps[id].Data;
-
-                    CheckFileStreamNotNull();
-                    fileStream.BaseStream.Seek(lumps[id].Offset, SeekOrigin.Begin);
-                    return fileStream.ReadBytes(lumps[id].Size);
+                    if (Filename != null)
+                    {
+                        _fileStream = new BinaryReader(File.Open(Filename, FileMode.Open, FileAccess.Read, FileShare.Read));
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("HOG file stream is not available.");
+                    }
                 }
-        }
-
-        /// <summary>
-        /// Gets the raw data of a given lump.
-        /// </summary>
-        /// <param name="filename">The filename of the lump to get the data of.</param>
-        /// <returns>A byte[] array of the lump's data.</returns>
-        public byte[] GetLumpData(string filename)
-        {
-            return GetLumpData(GetLumpNum(filename));
-        }
-
-        /// <summary>
-        /// Opens a lump in a stream for reading.
-        /// </summary>
-        /// <param name="id">The number of the lump to open.</param>
-        /// <returns>A stream containing the lump's data.</returns>
-        public Stream GetLumpAsStream(int id)
-        {
-            lock (lumpLock)
-            {
-                if (id < 0 || id >= lumps.Count) return null;
-                byte[] data = GetLumpData(id);
-                return new MemoryStream(data);
             }
-        }
-
-        /// <summary>
-        /// Opens a lump in a stream for reading.
-        /// </summary>
-        /// <param name="filename">The filename of the lump to open.</param>
-        /// <returns>A stream containing the lump's data.</returns>
-        public Stream GetLumpAsStream(string filename)
-        {
-            return GetLumpAsStream(GetLumpNum(filename));
         }
 
         /// <summary>
@@ -446,13 +252,12 @@ namespace LibDescent.Edit
         /// <param name="lump">The lump to add.</param>
         public void AddLump(HOGLump lump)
         {
-            lock (lumpLock)
+            lock (_lumpLock)
             {
-                lumps.Add(lump);
-                if (lumpNameMap != null && !lumpNameMap.ContainsKey(lump.Name))
+                Lumps.Add(lump);
+                if (_lumpNameMap != null && !_lumpNameMap.ContainsKey(lump.Name))
                 {
-                    lock (lumpNameLock)
-                        lumpNameMap[lump.Name] = lumps.Count - 1;
+                    _lumpNameMap[lump.Name] = Lumps.Count - 1;
                 }
             }
         }
@@ -465,21 +270,20 @@ namespace LibDescent.Edit
         /// <param name="lump">The lump to add.</param>
         public void ReplaceLump(HOGLump lump)
         {
-            lock (lumpLock)
-                lock (lumpNameLock)
+            lock (_lumpLock)
+            {
+                int lumpNum;
+                do
                 {
-                    int lumpNum;
-                    do
+                    lumpNum = GetLumpNum(lump.Name);
+                    if (lumpNum >= 0)
                     {
-                        lumpNum = GetLumpNum(lump.Name);
-                        if (lumpNum >= 0)
-                        {
-                            lumps.RemoveAt(lumpNum);
-                            lumpNameMap = null;
-                        }
-                    } while (lumpNum >= 0);
-                    AddLump(lump);
-                }
+                        Lumps.RemoveAt(lumpNum);
+                        _lumpNameMap = null;
+                    }
+                } while (lumpNum >= 0);
+                AddLump(lump);
+            }
         }
 
         /// <summary>
@@ -489,13 +293,12 @@ namespace LibDescent.Edit
         /// <param name="index">The index to add at.</param>
         public void AddLumpAt(HOGLump lump, int index)
         {
-            lock (lumpLock)
+            lock (_lumpLock)
             {
-                lumps.Insert(index, lump);
+                Lumps.Insert(index, lump);
                 //For now, invalidate the lump map when adding a lump at a given location
                 //since otherwise the old indicies would be messed up.
-                lock (lumpNameLock)
-                    lumpNameMap = null;
+                _lumpNameMap = null;
             }
         }
 
@@ -527,15 +330,14 @@ namespace LibDescent.Edit
         /// <param name="id">The number of the lump to delete.</param>
         public void DeleteLump(int id)
         {
-            lock (lumpLock)
+            lock (_lumpLock)
             {
-                lumps.RemoveAt(id);
+                Lumps.RemoveAt(id);
 
-                // We need to rebuild lumpNameDirectory because the indices may have all changed
+                // We need to rebuild _lumpNameMap because the indices may have all changed
                 // Do this on-demand (makes multiple deletions faster, especially if the index
                 // isn't being used)
-                lock (lumpNameLock)
-                    lumpNameMap = null;
+                _lumpNameMap = null;
             }
         }
 
@@ -556,7 +358,7 @@ namespace LibDescent.Edit
         /// <returns>All lumps in the HOG file that match the type requested.</returns>
         public List<HOGLump> GetLumpsByType(LumpType type)
         {
-            return lumps.Where(lump => lump.Type == type).ToList();
+            return Lumps.Where(lump => lump.Type == type).ToList();
         }
     }
 }

--- a/Tests/HogTests.cs
+++ b/Tests/HogTests.cs
@@ -1,4 +1,5 @@
 ﻿using LibDescent.Data;
+using LibDescent.Edit;
 using NUnit.Framework;
 using System.IO;
 using System.Text;
@@ -37,8 +38,7 @@ namespace LibDescent.Tests
             Assert.AreEqual("test.hxm", lumpHeader.Name);
             Assert.AreEqual(0x14, lumpHeader.Offset);
             Assert.AreEqual(32530, lumpHeader.Size);
-            //[ISB]: Classification is killed for non-editor HOG files. 
-            //Assert.AreEqual(LumpType.HXMFile, lumpHeader.Type);
+            Assert.AreEqual(LumpType.HXMFile, lumpHeader.Type);
 
             // Second lump - .pog
             lumpHeader = hogFile.Lumps[1];
@@ -46,7 +46,7 @@ namespace LibDescent.Tests
             Assert.AreEqual("test.pog", lumpHeader.Name);
             Assert.AreEqual(32567, lumpHeader.Offset);
             Assert.AreEqual(4128, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Unknown, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Unknown, lumpHeader.Type);
 
             // Third lump - .rl2
             lumpHeader = hogFile.Lumps[2];
@@ -54,7 +54,7 @@ namespace LibDescent.Tests
             Assert.AreEqual("test.rl2", lumpHeader.Name);
             Assert.AreEqual(36712, lumpHeader.Offset);
             Assert.AreEqual(7010, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Level, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Level, lumpHeader.Type);
         }
 
         [Test]
@@ -77,8 +77,7 @@ namespace LibDescent.Tests
             Assert.AreEqual(20, level.Segments.Count);
         }
 
-        //[ISB] TODO: Port to testing EditorHOGFile
-        /*[Test]
+        [Test]
         public void TestGetLumpByName()
         {
             var hogFile = new HOGFile(TestUtils.GetResourceStream("standard.hog"));
@@ -87,35 +86,18 @@ namespace LibDescent.Tests
             Assert.AreEqual(1, lumpNum);
             Assert.AreEqual(lumpNum, hogFile.GetLumpNum("TEST.POG"));
 
-            var lumpHeader = hogFile.GetLumpHeader("test.pog");
-            Assert.NotNull(lumpHeader);
-            Assert.AreSame(hogFile.GetLumpHeader(lumpNum), lumpHeader);
+            var lump = hogFile.GetLump("test.pog");
+            Assert.NotNull(lump);
+            Assert.AreSame(hogFile.Lumps[lumpNum], lump);
 
             var lumpData = hogFile.GetLumpData("test.pog");
             Assert.NotNull(lumpData);
-            Assert.AreEqual(lumpHeader.Size, lumpData.Length);
+            Assert.AreEqual(lump.Size, lumpData.Length);
 
             var lumpStream = hogFile.GetLumpAsStream("test.pog");
             Assert.NotNull(lumpStream);
-            Assert.AreEqual(lumpHeader.Size, lumpStream.Length);
-        }*/
-
-        //[ISB] TODO: Port to testing EditorHOGFile
-        /*[Test]
-        public void TestGetLumpsByType()
-        {
-            var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
-
-            var lumps = hogFile.GetLumpsByType(LumpType.Level);
-            Assert.NotNull(lumps);
-            Assert.AreEqual(3, lumps.Count);
-
-            foreach (var lump in lumps)
-            {
-                Assert.AreEqual(LumpType.Level, lump.Type);
-            }
-        }*/
-
+            Assert.AreEqual(lump.Size, lumpStream.Length);
+        }
 
         [Test]
         public void TestAddLump()
@@ -124,20 +106,20 @@ namespace LibDescent.Tests
 
             // Method 1 - set up lump manually
             var file1Data = TestUtils.GetArrayFromResourceStream("test.rdl");
-            var hogLump = new HOGLump("test.rdl", file1Data.Length, 0)
+            var hogLump = new HOGLump(hogFile, "test.rdl", (uint)file1Data.Length, 0)
             {
                 Data = file1Data
             };
             hogFile.Lumps.Add(hogLump);
             Assert.AreEqual(4, hogFile.NumLumps);
-            //Assert.AreEqual(3, hogFile.GetLumpNum("test.rdl")); //api change
+            Assert.AreEqual(3, hogFile.GetLumpNum("test.rdl"));
 
             // Method 2 - use constructor
             var file2Data = TestUtils.GetArrayFromResourceStream("test.rl2");
             hogLump = new HOGLump("test2.rl2", file2Data);
             hogFile.Lumps.Add(hogLump);
             Assert.AreEqual(5, hogFile.NumLumps);
-            //Assert.AreEqual(4, hogFile.GetLumpNum("test2.rl2"));
+            Assert.AreEqual(4, hogFile.GetLumpNum("test2.rl2"));
 
             // Make sure it writes correctly
             var memoryStream = new MemoryStream();
@@ -146,78 +128,11 @@ namespace LibDescent.Tests
 
             hogFile.Read(memoryStream);
             Assert.AreEqual(5, hogFile.NumLumps);
-            //Assert.AreEqual(3, hogFile.GetLumpNum("test.rdl"));
+            Assert.AreEqual(3, hogFile.GetLumpNum("test.rdl"));
             Assert.That(hogFile.GetLumpData(3), Is.EqualTo(file1Data));
-            //Assert.AreEqual(4, hogFile.GetLumpNum("test2.rl2"));
+            Assert.AreEqual(4, hogFile.GetLumpNum("test2.rl2"));
             Assert.That(hogFile.GetLumpData(4), Is.EqualTo(file2Data));
         }
-
-        //[ISB] TODO: Port to testing EditorHOGFile
-        /*[Test]
-        public void TestReplaceLump()
-        {
-            var hogFile = new HOGFile(TestUtils.GetResourceStream("standard.hog"));
-
-            // Method 1 - set up lump manually
-            var file1Data = TestUtils.GetArrayFromResourceStream("test.rdl");
-            var hogLump = new HOGLump("test.rdl", file1Data.Length, 0)
-            {
-                Data = file1Data
-            };
-            hogFile.AddLump(hogLump);
-            //Assert.AreEqual(4, hogFile.NumLumps);
-
-            int numLumps = hogFile.NumLumps;
-            hogFile.ReplaceLump(hogLump);
-            Assert.AreEqual(numLumps, hogFile.NumLumps);
-        }*/
-
-        //[ISB] TODO: Port to testing EditorHOGFile
-        /*
-        [Test]
-        public void TestAddFile()
-        {
-            var hogFile = new HOGFile(TestUtils.GetResourceStream("standard.hog"));
-            var filename = "test.rdl";
-            //[ISB] this API is gone from normal HOGFile
-            hogFile.AddFile(filename, TestUtils.GetResourceStream(filename));
-
-            var memoryStream = new MemoryStream();
-            hogFile.Write(memoryStream);
-            memoryStream.Seek(0, SeekOrigin.Begin);
-
-            hogFile.Read(memoryStream);
-            Assert.AreEqual(4, hogFile.NumLumps);
-            Assert.AreEqual(3, hogFile.GetLumpNum(filename));
-            Assert.That(hogFile.GetLumpData(filename), Is.EqualTo(TestUtils.GetArrayFromResourceStream(filename)));
-        }*/
-
-        /*[Test]
-        public void TestDeleteLump()
-        {
-            var hogFile = new HOGFile(TestUtils.GetResourceStream("standard.hog"));
-            //hogFile.DeleteLump(1);
-            hogFile.Lumps.RemoveAt(1);
-            Assert.AreEqual(2, hogFile.NumLumps);
-
-            // Other files should have been reassigned
-            Assert.IsNotNull(hogFile.GetLumpHeader(0));
-            Assert.AreEqual("test.hxm", hogFile.GetLumpHeader(0).Name);
-            Assert.IsNotNull(hogFile.GetLumpHeader(1));
-            Assert.AreEqual("test.rl2", hogFile.GetLumpHeader(1).Name);
-            Assert.IsNull(hogFile.GetLumpHeader(2));
-            Assert.AreEqual(-1, hogFile.GetLumpNum("test.pog"));
-
-            // Check persistence
-            var memoryStream = new MemoryStream();
-            hogFile.Write(memoryStream);
-            memoryStream.Seek(0, SeekOrigin.Begin);
-
-            hogFile.Read(memoryStream);
-            Assert.AreEqual(2, hogFile.NumLumps);
-            Assert.AreEqual("test.rl2", hogFile.Lumps[1].Name);
-            Assert.AreEqual(-1, hogFile.GetLumpNum("test.pog"));
-        }*/
 
         [Test]
         public void TestCreateNewHog()
@@ -226,7 +141,6 @@ namespace LibDescent.Tests
             Assert.AreEqual(0, hogFile.NumLumps);
 
             var filename = "test.rdl";
-            //hogFile.AddFile(filename, TestUtils.GetResourceStream(filename));
             HOGLump lump = new HOGLump(filename, TestUtils.GetArrayFromResourceStream(filename));
             hogFile.Lumps.Add(lump);
             Assert.AreEqual(1, hogFile.NumLumps);
@@ -238,9 +152,8 @@ namespace LibDescent.Tests
             hogFile.Read(memoryStream);
             Assert.AreEqual(1, hogFile.NumLumps);
 
-            //TODO: api change
-            //Assert.IsNotNull(hogFile.GetLumpHeader(filename));
-            //Assert.That(hogFile.GetLumpData(filename), Is.EqualTo(TestUtils.GetArrayFromResourceStream(filename)));
+            Assert.IsNotNull(hogFile.GetLump(filename));
+            Assert.That(hogFile.GetLumpData(filename), Is.EqualTo(TestUtils.GetArrayFromResourceStream(filename)));
         }
 
         [Test]
@@ -263,84 +176,84 @@ namespace LibDescent.Tests
             Assert.AreEqual("level1.msg", lumpHeader.Name);
             Assert.AreEqual(0x14, lumpHeader.Offset);
             Assert.AreEqual(246, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Text, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Text, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[1];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level2.msg", lumpHeader.Name);
             Assert.AreEqual(283, lumpHeader.Offset);
             Assert.AreEqual(246, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Text, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Text, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[2];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level3.msg", lumpHeader.Name);
             Assert.AreEqual(546, lumpHeader.Offset);
             Assert.AreEqual(246, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Text, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Text, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[3];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level1.rl2", lumpHeader.Name);
             Assert.AreEqual(1065, lumpHeader.Offset);
             Assert.AreEqual(75266, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Level, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Level, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[4];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level1.lgt", lumpHeader.Name);
             Assert.AreEqual(76604, lumpHeader.Offset);
             Assert.AreEqual(3640, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.LGTMap, lumpHeader.Type);
+            Assert.AreEqual(LumpType.LGTMap, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[5];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level1.clr", lumpHeader.Name);
             Assert.AreEqual(80517, lumpHeader.Offset);
             Assert.AreEqual(11830, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.CLRMap, lumpHeader.Type);
+            Assert.AreEqual(LumpType.CLRMap, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[6];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level3.rl2", lumpHeader.Name);
             Assert.AreEqual(92620, lumpHeader.Offset);
             Assert.AreEqual(57744, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Level, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Level, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[7];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level3.lgt", lumpHeader.Name);
             Assert.AreEqual(150637, lumpHeader.Offset);
             Assert.AreEqual(3640, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.LGTMap, lumpHeader.Type);
+            Assert.AreEqual(LumpType.LGTMap, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[8];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level3.clr", lumpHeader.Name);
             Assert.AreEqual(154550, lumpHeader.Offset);
             Assert.AreEqual(11830, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.CLRMap, lumpHeader.Type);
+            Assert.AreEqual(LumpType.CLRMap, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[9];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level2.rl2", lumpHeader.Name);
             Assert.AreEqual(166653, lumpHeader.Offset);
             Assert.AreEqual(109608, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Level, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Level, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[10];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level2.lgt", lumpHeader.Name);
             Assert.AreEqual(276534, lumpHeader.Offset);
             Assert.AreEqual(3640, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.LGTMap, lumpHeader.Type);
+            Assert.AreEqual(LumpType.LGTMap, lumpHeader.Type);
 
             lumpHeader = hogFile.Lumps[11];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level2.clr", lumpHeader.Name);
             Assert.AreEqual(280447, lumpHeader.Offset);
             Assert.AreEqual(11830, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.CLRMap, lumpHeader.Type);
+            Assert.AreEqual(LumpType.CLRMap, lumpHeader.Type);
         }
 
         [Test]
@@ -360,25 +273,26 @@ namespace LibDescent.Tests
             Assert.AreEqual("level1.msg", lumpHeader.Name);
             Assert.AreEqual(0x14, lumpHeader.Offset);
             Assert.AreEqual(246, lumpHeader.Size);
-            //Assert.AreEqual(LumpType.Text, lumpHeader.Type);
+            Assert.AreEqual(LumpType.Text, lumpHeader.Type);
 
-            /*lumpHeader = hogFile.GetLumpHeader("level1.rl2");
+            lumpHeader = hogFile.GetLump("level1.rl2");
             Assert.NotNull(lumpHeader);
             Assert.AreEqual("level1.rl2", lumpHeader.Name);
             // Moves because the new header is standard - not using long filename
             Assert.AreEqual(809, lumpHeader.Offset);
             Assert.AreEqual(75266, lumpHeader.Size);
-            Assert.AreEqual(LumpType.Level, lumpHeader.Type);*/
+            Assert.AreEqual(LumpType.Level, lumpHeader.Type);
         }
 
-        /*[Test]
+        [Test]
         public void TestXLHogAddLongFilename()
         {
             var hogFile = new HOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
 
             var filename = "testlongfilename.txt";
             var data = Encoding.ASCII.GetBytes("test");
-            hogFile.AddLump(new HOGLump(filename, data));
+            var lump = new HOGLump(filename, data);
+            hogFile.Lumps.Add(lump);
 
             // Write to file
             var memoryStream = new MemoryStream();
@@ -390,11 +304,85 @@ namespace LibDescent.Tests
             Assert.AreEqual(13, hogFile.NumLumps);
 
             var lumpNum = hogFile.NumLumps - 1;
-            var lumpHeader = hogFile.GetLumpHeader(lumpNum);
+            var lumpHeader = hogFile.Lumps[lumpNum];
             Assert.NotNull(lumpHeader);
             Assert.AreEqual(filename, lumpHeader.Name);
             Assert.AreEqual(data.Length, lumpHeader.Size);
             Assert.That(hogFile.GetLumpData(lumpNum), Is.EqualTo(data));
-        }*/
+        }
+
+        [Test]
+        public void TestGetLumpsByType()
+        {
+            var hogFile = new EditorHOGFile(TestUtils.GetResourceStream("d2x-xl.hog"));
+
+            var lumps = hogFile.GetLumpsByType(LumpType.Level);
+            Assert.NotNull(lumps);
+            Assert.AreEqual(3, lumps.Count);
+
+            foreach (var lump in lumps)
+            {
+                Assert.AreEqual(LumpType.Level, lump.Type);
+            }
+        }
+
+        [Test]
+        public void TestReplaceLump()
+        {
+            var hogFile = new EditorHOGFile(TestUtils.GetResourceStream("standard.hog"));
+
+            // Method 1 - set up lump manually
+            var file1Data = TestUtils.GetArrayFromResourceStream("test.rdl");
+            var hogLump = new HOGLump("test.rdl", file1Data);
+            hogFile.AddLump(hogLump);
+            Assert.AreEqual(4, hogFile.NumLumps);
+
+            int numLumps = hogFile.NumLumps;
+            hogFile.ReplaceLump(hogLump);
+            Assert.AreEqual(numLumps, hogFile.NumLumps);
+        }
+
+        [Test]
+        public void TestAddFile()
+        {
+            var hogFile = new EditorHOGFile(TestUtils.GetResourceStream("standard.hog"));
+            var filename = "test.rdl";
+            hogFile.AddFile(filename, TestUtils.GetResourceStream(filename));
+
+            var memoryStream = new MemoryStream();
+            hogFile.Write(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            hogFile.Read(memoryStream);
+            Assert.AreEqual(4, hogFile.NumLumps);
+            Assert.AreEqual(3, hogFile.GetLumpNum(filename));
+            Assert.That(hogFile.GetLumpData(filename), Is.EqualTo(TestUtils.GetArrayFromResourceStream(filename)));
+        }
+
+        [Test]
+        public void TestDeleteLump()
+        {
+            var hogFile = new EditorHOGFile(TestUtils.GetResourceStream("standard.hog"));
+            hogFile.DeleteLump(1);
+            Assert.AreEqual(2, hogFile.NumLumps);
+
+            // Other files should have been reassigned
+            Assert.IsNotNull(hogFile.GetLumpHeader(0));
+            Assert.AreEqual("test.hxm", hogFile.GetLumpHeader(0).Name);
+            Assert.IsNotNull(hogFile.GetLumpHeader(1));
+            Assert.AreEqual("test.rl2", hogFile.GetLumpHeader(1).Name);
+            Assert.IsNull(hogFile.GetLumpHeader(2));
+            Assert.AreEqual(-1, hogFile.GetLumpNum("test.pog"));
+
+            // Check persistence
+            var memoryStream = new MemoryStream();
+            hogFile.Write(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            hogFile.Read(memoryStream);
+            Assert.AreEqual(2, hogFile.NumLumps);
+            Assert.AreEqual("test.rl2", hogFile.Lumps[1].Name);
+            Assert.AreEqual(-1, hogFile.GetLumpNum("test.pog"));
+        }
     }
 }

--- a/Tests/LibDescent.Tests.csproj
+++ b/Tests/LibDescent.Tests.csproj
@@ -52,6 +52,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Data\LibDescent.Data.csproj" />
+    <ProjectReference Include="..\Edit\LibDescent.Edit.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Tests/MiscLevelLoadTests.cs
+++ b/Tests/MiscLevelLoadTests.cs
@@ -61,12 +61,11 @@ namespace LibDescent.Tests
             string filePath = "";
             using var stream = new FileStream(filePath.Replace("\"", null), FileMode.Open, FileAccess.Read);
             var hogFile = new HOGFile(stream);
-            for (int i = 0; i < hogFile.Lumps.Count; i++)
+            foreach (var lump in hogFile.Lumps)
             {
-                if (hogFile.Lumps[i].Name.ToLower().EndsWith(".rdl") || hogFile.Lumps[i].Name.ToLower().EndsWith(".rl2"))
+                if (lump.Name.ToLower().EndsWith(".rdl") || lump.Name.ToLower().EndsWith(".rl2"))
                 {
-                    using var levelStream = hogFile.GetLumpAsStream(i);
-                    var level = LevelFactory.CreateFromStream(levelStream);
+                    var level = LevelFactory.CreateFromStream(lump.DataAsStream);
                     Assert.Greater(level.Segments.Count, 0);
                 }
             }


### PR DESCRIPTION
The main purpose of these changes was to make HOGFile and EditorHOGFile more straightforward to work with, particularly from scripting environments like PowerShell, without accidentally shooting yourself in the foot by making changes that leave things in an invalid state.

Unfortunately I think some of the changes will not compile with Descent 2 Workshop as-is, and minor alterations might be required next time that gets a submodule update.